### PR TITLE
Cleanup removed ability types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ability Schema:
 ```js
 const ability = {
     name: "Name of the ability",
-    type: ATTACK|SPECIAL|CAST|DASH|REVENGE|OTHER
+    type: ATTACK|SPECIAL|CAST|DASH|OTHER
     info: value => `message for the boss to respond with`
     values: {
         [RARITY]: {

--- a/features/aphrodite.feature
+++ b/features/aphrodite.feature
@@ -5,7 +5,7 @@ Feature: User can ask for information about Aphrodite
         And a channel {sneakyteak}
         When the user says to the bot {!aphrodite}
         Then the bot responds with {Aphrodite, Goddess of Love. Her powers weaken enemies causing them to do less damage}
-        And the bot responds with {[attack] [special] [cast] [dash] [revenge] [other]}
+        And the bot responds with {[attack] [special] [cast] [dash] [other]}
 
     Scenario: User can ask for attack information about Aphrodite
         Given PENDING: need info
@@ -37,14 +37,6 @@ Feature: User can ask for information about Aphrodite
         When the user says to the bot {!aphrodite cast}
         Then the bot responds with {Shatter Shot (Cast)}
         And the bot responds with {Cast shoots six short range projectiles that each deal (c:15) damage}
-
-    Scenario: User can ask for revenge information about Aphrodite
-        Given PENDING: need info
-        And a user {user1}
-        And a channel {sneakyteak}
-        When the user says to the bot {!aphrodite revenge}
-        Then the bot responds with {Wave of Despair (Revenge)}
-        And the bot responds with {Taking damage deals (c:14 r:17) damage to nearby enemies and applies weak}
 
     Scenario: User can ask for the names of other abilities for Aphrodite
         Given a user {user1}

--- a/features/ares.feature
+++ b/features/ares.feature
@@ -4,7 +4,7 @@ Feature: User can ask for information about Ares
         Given a user {user1}
         And a channel {sneakyteak}
         When the user says to the bot {!ares}
-        Then the bot responds with {Ares, God of War. His powers cause spinning clouds of blades or damaging curses. [attack] [special] [cast] [dash] [revenge] [other]}
+        Then the bot responds with {Ares, God of War. His powers cause spinning clouds of blades or damaging curses. [attack] [special] [cast] [dash]] [other]}
 
     Scenario: User can ask for attack information about Ares
         Given a user {user1}
@@ -31,12 +31,6 @@ Feature: User can ask for information about Ares
         And a channel {sneakyteak}
         When the user says to the bot {!ares cast}
         Then the bot responds with {True Shot (Cast) - Cast seeks enemies and deals (e:149-179) damage}
-
-    Scenario: User can ask for revenge information about Ares
-        Given a user {user1}
-        And a channel {sneakyteak}
-        When the user says to the bot {!ares revenge}
-        Then the bot responds with {Curse of Vengeance (Revenge) - Taking damage causes nearby enemies to take (e:140) damage a short time later}
 
     Scenario: User can ask for the names of other abilities for Ares
         Given a user {user1}

--- a/features/artemis.feature
+++ b/features/artemis.feature
@@ -4,7 +4,7 @@ Feature: User can ask for information about Artemis
         Given a user {user1}
         And a channel {sneakyteak}
         When the user says to the bot {!artemis}
-        Then the bot responds with {Artemis, Goddess of the Hunt. Her powers cause critical hits and create seeking projectiles. [attack] [special] [cast] [dash] [revenge] [other]}
+        Then the bot responds with {Artemis, Goddess of the Hunt. Her powers cause critical hits and create seeking projectiles. [attack] [special] [cast] [dash] [other]}
 
     Scenario: User can ask for attack information about Artemis
         Given a user {user1}
@@ -29,12 +29,6 @@ Feature: User can ask for information about Artemis
         And a channel {sneakyteak}
         When the user says to the bot {!artemis cast}
         Then the bot responds with {True Shot (Cast) - Cast seeks enemies and deals (e:149-179) damage}
-
-    Scenario: User can ask for revenge information about Artemis
-        Given a user {user1}
-        And a channel {sneakyteak}
-        When the user says to the bot {!artemis revenge}
-        Then the bot responds with {Heaven's Vengeance (Revenge) - Taking damage strikes nearby enemies for (e:151-173) damage}
 
     Scenario: User can ask for the names of other abilities for Artemis
         Given a user {user1}

--- a/features/athena.feature
+++ b/features/athena.feature
@@ -4,7 +4,7 @@ Feature: User can ask for information about Athena
         Given a user {user1}
         And a channel {sneakyteak}
         When the user says to the bot {!athena}
-        Then the bot responds with {Athena, Goddess of Wisdom. Her powers deflect attacks. [attack] [special] [cast] [dash] [revenge] [other]}
+        Then the bot responds with {Athena, Goddess of Wisdom. Her powers deflect attacks. [attack] [special] [cast] [dash] [other]}
 
     Scenario: User can ask for attack information about Athena
         Given a user {user1}
@@ -30,12 +30,6 @@ Feature: User can ask for information about Athena
         And a channel {sneakyteak}
         When the user says to the bot {!athena cast}
         Then the bot responds with {Titan Toppler (Dash) - Your dash is now slower but deals (e:30) and deflects}
-
-    Scenario: User can ask for revenge information about Athena
-        Given a user {user1}
-        And a channel {sneakyteak}
-        When the user says to the bot {!athena revenge}
-        Then the bot responds with {Brilliant Riposte (Revenge) - Taking damage causes you to deflect and deal (c:20 r:27) damage to nearby enemies}
 
     Scenario: User can ask for the names of other abilities for Athena
         Given a user {user1}

--- a/features/demeter.feature
+++ b/features/demeter.feature
@@ -5,7 +5,7 @@ Feature: Users can ask about Demeter
         And a channel {sneakyteak}
         When the user says to the bot {!demeter}
         Then the bot responds with {Demeter, God of the Harvest}
-        And the bot responds with {[attack] [special] [cast] [dash] [aid] [other]}
+        And the bot responds with {[attack] [special] [cast] [dash] [other]}
 
     Scenario: Abilites with 2 values should have only 1 formatted
         Given a user {user1}

--- a/features/demeter.feature
+++ b/features/demeter.feature
@@ -5,7 +5,7 @@ Feature: Users can ask about Demeter
         And a channel {sneakyteak}
         When the user says to the bot {!demeter}
         Then the bot responds with {Demeter, God of the Harvest}
-        And the bot responds with {[attack] [special] [cast] [dash] [revenge] [aid] [other]}
+        And the bot responds with {[attack] [special] [cast] [dash] [aid] [other]}
 
     Scenario: Abilites with 2 values should have only 1 formatted
         Given a user {user1}

--- a/features/poseidon.feature
+++ b/features/poseidon.feature
@@ -5,7 +5,7 @@ Feature: User can ask for information about Poseidon
         And a channel {sneakyteak}
         When the user says to the bot {!poseidon}
         Then the bot responds with {Poseidon, God of the Sea. His powers knock enemies away.}
-        And the bot responds with {[attack] [special] [cast] [dash] [revenge] [other]}
+        And the bot responds with {[attack] [special] [cast] [dash] [other]}
 
     Scenario: User can ask for attack information about Poseidon
         Given a user {user1}
@@ -34,13 +34,6 @@ Feature: User can ask for information about Poseidon
         When the user says to the bot {!poseidon cast}
         Then the bot responds with {Storm Shot (Cast)}
         And the bot responds with {Cast deals (r:77-79) damage in an area and knocks enemies back}
-
-    Scenario: User can ask for revenge information about Poseidon
-        Given PENDING: need info
-        And a user {user1}
-        And a channel {sneakyteak}
-        When the user says to the bot {!poseidon revenge}
-        Then the bot responds with {Heaven's Vengeance (Revenge) - Taking damage strikes nearby enemies for (e:151-173) damage}
 
     Scenario: User can ask for the names of other abilities for Poseidon
         Given a user {user1}

--- a/features/zeus.feature
+++ b/features/zeus.feature
@@ -4,7 +4,7 @@ Feature: User can ask for information about Zeus
         Given a user {user1}
         And a channel {sneakyteak}
         When the user says to the bot {!zeus}
-        Then the bot responds with {Zeus, God of Thunder. His powers create bouncing lightning projectiles. [attack] [special] [cast] [dash] [revenge] [other]}
+        Then the bot responds with {Zeus, God of Thunder. His powers create bouncing lightning projectiles. [attack] [special] [cast] [dash] [other]}
 
     Scenario: User can ask for attack information about Zeus
         Given a user {user1}
@@ -29,12 +29,6 @@ Feature: User can ask for information about Zeus
         And a channel {sneakyteak}
         When the user says to the bot {!zeus cast}
         Then the bot responds with {Electric Shot (Cast) - Cast bounces and deals (c:60 r:84-86 e:122) damage}
-
-    Scenario: User can ask for revenge information about Zeus
-        Given a user {user1}
-        And a channel {sneakyteak}
-        When the user says to the bot {!zeus revenge}
-        Then the bot responds with {Heaven's Vengeance (Revenge) - Taking damage strikes nearby enemies for (e:151-173) damage}
 
     Scenario: User can ask for the names of other abilities for Zeus
         Given a user {user1}

--- a/src/commands/god.js
+++ b/src/commands/god.js
@@ -10,7 +10,6 @@ const godOptions = [
   "special",
   "cast",
   "dash",
-  "revenge",
   "aid",
   "other",
 ]

--- a/src/commands/god.js
+++ b/src/commands/god.js
@@ -10,7 +10,6 @@ const godOptions = [
   "special",
   "cast",
   "dash",
-  "aid",
   "other",
 ]
   .map((opt) => `[${opt}]`)

--- a/src/data/gods/abilityTypes.js
+++ b/src/data/gods/abilityTypes.js
@@ -2,9 +2,8 @@ const ATTACK = "Attack";
 const SPECIAL = "Special";
 const CAST = "Cast";
 const DASH = "Dash";
-const REVENGE = "Revenge";
 const OTHER = "Other";
 const HEX = "Wrath";
 const AID = "Aid";
 
-module.exports = { ATTACK, SPECIAL, CAST, DASH, REVENGE, OTHER, HEX, AID };
+module.exports = { ATTACK, SPECIAL, CAST, DASH, OTHER, HEX, AID };

--- a/src/data/gods/abilityTypes.js
+++ b/src/data/gods/abilityTypes.js
@@ -4,6 +4,5 @@ const CAST = "Cast";
 const DASH = "Dash";
 const OTHER = "Other";
 const HEX = "Wrath";
-const AID = "Aid";
 
-module.exports = { ATTACK, SPECIAL, CAST, DASH, OTHER, HEX, AID };
+module.exports = { ATTACK, SPECIAL, CAST, DASH, OTHER, HEX };

--- a/src/data/gods/abilityTypes.js
+++ b/src/data/gods/abilityTypes.js
@@ -3,6 +3,5 @@ const SPECIAL = "Special";
 const CAST = "Cast";
 const DASH = "Dash";
 const OTHER = "Other";
-const HEX = "Wrath";
 
-module.exports = { ATTACK, SPECIAL, CAST, DASH, OTHER, HEX };
+module.exports = { ATTACK, SPECIAL, CAST, DASH, OTHER, };

--- a/src/data/gods/aphrodite.js
+++ b/src/data/gods/aphrodite.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/aphrodite.js
+++ b/src/data/gods/aphrodite.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -106,13 +105,6 @@ const lifeAffirmation = {
   },
 };
 
-const revenge = {
-  name: "Unknown",
-  type: REVENGE,
-  info: (value) => `Unknown`,
-  values: calculateFlat(50, true),
-};
-
 const secretCrush = {
   name: "Secret Crash",
   type: OTHER,
@@ -127,7 +119,6 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   "secret crush": secretCrush,
   "shameless attitude": shamelessAttitude,

--- a/src/data/gods/apollo.js
+++ b/src/data/gods/apollo.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/apollo.js
+++ b/src/data/gods/apollo.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -107,9 +106,9 @@ const superNova = {
   },
 };
 
-const revenge = {
+const lightSmite = {
   name: "Light Smite",
-  type: REVENGE,
+  type: OTHER,
   info: (value) =>
     `After you take damage, your foes takes ${value} damage and you inflict Daze on all foes`,
   values: {
@@ -178,7 +177,6 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   "lucid gain": lucidGain,
   "extra dose": extraDose,
@@ -189,6 +187,7 @@ const abilities = {
   backBurner,
   criticalMiss,
   stellarSlam,
+  lightSmite,
 };
 
 const base = {

--- a/src/data/gods/artemis.js
+++ b/src/data/gods/artemis.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -102,13 +101,6 @@ const dash = {
   },
 };
 
-const revenge = {
-  name: "None",
-  type: REVENGE,
-  info: (value) => `Artemis does not have a revenge ability`,
-  values: {},
-};
-
 const lethalSnare = {
   name: "Lethal Snare",
   type: OTHER,
@@ -181,7 +173,6 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   "support fire": supportFire,
   "lethal snare": lethalSnare,

--- a/src/data/gods/artemis.js
+++ b/src/data/gods/artemis.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/demeter.js
+++ b/src/data/gods/demeter.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/demeter.js
+++ b/src/data/gods/demeter.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -96,20 +95,6 @@ const dash = {
     [HEROIC]: {
       1: 37.5,
     },
-  },
-};
-
-const revenge = {
-  name: "Unknown",
-  type: REVENGE,
-  info: () => `Unknown`,
-  values: {
-    [COMMON]: { 1: 10 },
-    [RARE]: {
-      1: 15,
-    },
-    [EPIC]: { 1: 20 },
-    [HEROIC]: { 1: 25 },
   },
 };
 
@@ -217,7 +202,6 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   rareCrop,
   weedKiller,

--- a/src/data/gods/hephaestus.js
+++ b/src/data/gods/hephaestus.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/hephaestus.js
+++ b/src/data/gods/hephaestus.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -128,13 +127,6 @@ const uncannyFortitude = {
   },
 };
 
-const revenge = {
-  name: "Unknown",
-  type: REVENGE,
-  info: (value) => `Unknown`,
-  values: calculateFlat(50, true),
-};
-
 const roomTemperature = {
   name: "Room Temperature",
   type: DUO,
@@ -179,7 +171,6 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   toughTrade,
   fixedGain,

--- a/src/data/gods/hera.js
+++ b/src/data/gods/hera.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/hera.js
+++ b/src/data/gods/hera.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -98,13 +97,6 @@ const keenIntuition = {
   },
 };
 
-const revenge = {
-  name: "Unknown",
-  type: REVENGE,
-  info: (value) => `Unknown`,
-  values: calculateFlat(50, true),
-};
-
 const kingsRansom = {
   name: "King's Ransom",
   type: DUO,
@@ -179,7 +171,6 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   bornGain,
   engagementRing,

--- a/src/data/gods/hermes.js
+++ b/src/data/gods/hermes.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -120,9 +119,9 @@ const quickBuck = {
   },
 };
 
-const revenge = {
+const greaterEvasion = {
   name: "Greater Evasion",
-  type: REVENGE,
+  type: OTHER,
   info: () =>
     `Whenever you are struck, you have a ${value} chance to Dodge any damage`,
   values: {
@@ -143,12 +142,12 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   meanStreak,
   hardTarget,
   wittyRetort,
   quickBuck,
+  greaterEvasion,
   savedBreath,
 };
 

--- a/src/data/gods/hermes.js
+++ b/src/data/gods/hermes.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const { mapValues, toArray } = require("lodash");
 

--- a/src/data/gods/hestia.js
+++ b/src/data/gods/hestia.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/hestia.js
+++ b/src/data/gods/hestia.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -128,13 +127,6 @@ const naturalGas = {
   },
 };
 
-const revenge = {
-  name: "Unknown",
-  type: REVENGE,
-  info: (value) => `Unknown`,
-  values: calculateFlat(50, true),
-};
-
 const funeralPyre = {
   name: "Funeral Pyre",
   type: DUO,
@@ -215,7 +207,6 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   hearthGain,
   controlledBurn,

--- a/src/data/gods/poseidon.js
+++ b/src/data/gods/poseidon.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/poseidon.js
+++ b/src/data/gods/poseidon.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -70,13 +69,6 @@ const dash = {
       2: 120,
     },
   },
-};
-
-const revenge = {
-  name: "None",
-  type: REVENGE,
-  info: () => `Poseidon does not have a revenge ability.`,
-  values: {},
 };
 
 const doubleUp = {
@@ -165,7 +157,6 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   waterFitness,
   hydraulicMight,

--- a/src/data/gods/zeus.js
+++ b/src/data/gods/zeus.js
@@ -6,7 +6,6 @@ const {
   CAST,
   DASH,
   OTHER,
-  AID,
 } = require("./abilityTypes");
 const {
   calculatePercentage,

--- a/src/data/gods/zeus.js
+++ b/src/data/gods/zeus.js
@@ -5,7 +5,6 @@ const {
   SPECIAL,
   CAST,
   DASH,
-  REVENGE,
   OTHER,
   AID,
 } = require("./abilityTypes");
@@ -96,9 +95,9 @@ const dash = {
   },
 };
 
-const revenge = {
+const divineVengeance = {
   name: "Divine Vengeance",
-  type: REVENGE,
+  type: OTHER,
   info: (value) =>
     `After you take damage, your foe is stuck by lightning for ${value}, and again 50% of the time (up to 3 times)`,
   values: {
@@ -217,9 +216,9 @@ const abilities = {
   attack,
   special,
   dash,
-  revenge,
   cast,
   lightningLance,
+  divineVengeance,
   ionicGain,
   stormRing,
   staticShock,


### PR DESCRIPTION
REVENGE, AID, and WRATH ability types don't exist (so far) in Hades II. Removed all references to these ability types, but preserved abilities that should just be classified as OTHER now.