### PR TITLE
Tons of content updates from the in-game codex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "express": "^4.19.2",
         "lodash": "^4.17.21",
         "tmi.js": "^1.8.5",
-        "ts-node": "^10.9.2",
         "winston": "^3.13.0"
       },
       "devDependencies": {
@@ -31,6 +30,7 @@
         "chai-as-promised": "^7.1.1",
         "nodemon": "^3.1.0",
         "sinon": "^17.0.1",
+        "ts-node": "^10.9.2",
         "typescript": "^5.4.5"
       },
       "engines": {
@@ -49,6 +49,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -520,6 +521,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -527,12 +529,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -594,22 +598,26 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -692,6 +700,7 @@
       "version": "20.12.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
       "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -794,6 +803,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -805,6 +815,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -873,7 +884,8 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -1277,7 +1289,8 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2135,7 +2148,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -3035,6 +3049,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -3077,6 +3092,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -3112,6 +3128,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3129,7 +3146,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -3184,7 +3202,8 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -3377,6 +3396,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/src/data/gods/abilityTypes.ts
+++ b/src/data/gods/abilityTypes.ts
@@ -4,7 +4,8 @@ export type BoonType =
   | typeof CAST
   | typeof DASH
   | typeof GAIN
-  | typeof OTHER;
+  | typeof OTHER
+  | typeof INFUSION;
 
 const ATTACK = "Attack";
 const SPECIAL = "Special";
@@ -12,6 +13,7 @@ const CAST = "Cast";
 const DASH = "Dash";
 const GAIN = "Gain";
 const OTHER = "Other";
+const INFUSION = "Infusion";
 
-const abilities = [ATTACK, SPECIAL, CAST, DASH, GAIN, OTHER];
-export { ATTACK, SPECIAL, CAST, DASH, OTHER, GAIN, abilities };
+const abilities = [ATTACK, SPECIAL, CAST, DASH, GAIN, OTHER, INFUSION];
+export { ATTACK, CAST, DASH, GAIN, INFUSION, OTHER, SPECIAL, abilities };

--- a/src/data/gods/aphrodite.ts
+++ b/src/data/gods/aphrodite.ts
@@ -1,10 +1,30 @@
 import { mapValues, toArray } from "lodash";
 import { notNullOrUndefined } from "../../utils/arrayUtils";
-import { ATTACK, CAST, DASH, OTHER, SPECIAL, GAIN, } from "./abilityTypes";
-import { AIR, WATER } from "./elements";
+import {
+  ATTACK,
+  CAST,
+  DASH,
+  GAIN,
+  INFUSION,
+  OTHER,
+  SPECIAL,
+} from "./abilityTypes";
+import { lucidGain, novaFlourish, novaStrike, solarRing } from "./apollo";
+import { plentifulForage, winterCoat } from "./demeter";
+import { AIR, COSMIC, WATER } from "./elements";
 import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
+import { anvilRing, fixedGain, smithySprint } from "./hephaestus";
+import { nastyComeback, nexusSprint, swornFlourish, swornStrike } from "./hera";
+import { hearthGain, smolderRing, sootSprint } from "./hestia";
+import {
+  breakerSprint,
+  geyserRing,
+  waveFlourish,
+  waveStrike,
+} from "./poseidon";
 import { COMMON, DUO, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
+import { heavenFlourish, heavenStrike } from "./zeus";
 
 const info =
   "Aphrodite, Goddess of Love. Her powers weaken enemies causing them to do less damage";
@@ -34,13 +54,17 @@ const attack: Boon = {
   },
 };
 
+export const flutterStrike = attack;
+
 const special: Boon = {
-  name: "Fluttery Flourish",
+  name: "Flutter Flourish",
   type: SPECIAL,
   element: WATER,
-  info: (value) => `Unknown`,
+  info: (value) => `Your Specials deal ${value} more damage to nearby foes`,
   values: { [COMMON]: { 1: "80%" } },
 };
+
+export const flutterFlourish = special;
 
 const cast: Boon = {
   name: "Rapture Ring",
@@ -57,17 +81,22 @@ const cast: Boon = {
   },
 };
 
+export const raptureRing = cast;
+
 const dash: Boon = {
-  name: "Unknown",
+  name: "Passion Dash",
   type: DASH,
   element: AIR,
-  info: (value) => `Unknown`,
+  info: (value) =>
+    `Your Dash blasts foes near where you start and end for ${value}, and inflicts [weak]`,
   values: {
-    [RARE]: {
-      1: 30,
+    [COMMON]: {
+      1: 20,
     },
   },
 };
+
+export const passionDash = dash;
 
 const gain: Boon = {
   name: "Glamour Gain",
@@ -81,16 +110,28 @@ const gain: Boon = {
   },
 };
 
-const shamelessAttitude: Boon = {
+export const glamourGain = gain;
+
+const wispyWiles: Boon = {
+  name: "Wispy Wiles",
+  type: INFUSION,
+  info: (value) =>
+    `While you have at least 4 [air], you have a ${value} chance to dodge any damage`,
+  values: {
+    [COMMON]: { 1: "15%" },
+  },
+};
+
+export const shamelessAttitude: Boon = {
   name: "Shameless Attitude",
   type: OTHER,
   element: AIR,
   info: (value) =>
     `While you have at least 80% health, you deal ${value} more damage`,
-  values: { [RARE]: { 1: "15%" } },
+  values: { [COMMON]: { 1: "10%" }, [RARE]: { 1: "15%" } },
 };
 
-const heartBreaker: Boon = {
+export const heartBreaker: Boon = {
   name: "Heart Breaker",
   type: OTHER,
   element: WATER,
@@ -101,7 +142,18 @@ const heartBreaker: Boon = {
   },
 };
 
-const lifeAffirmation: Boon = {
+export const healthyRebound: Boon = {
+  name: "Healthy Rebound",
+  type: OTHER,
+  element: WATER,
+  info: (value) =>
+    `WHenever you exit a Location, restore 100% of health if you are above ${value} health`,
+  values: {
+    [COMMON]: { 1: "80%" },
+  },
+};
+
+export const lifeAffirmation: Boon = {
   name: "Life Affirmation",
   type: OTHER,
   element: AIR,
@@ -123,14 +175,56 @@ const secretCrush: Boon = {
   },
 };
 
+const brokenResolve: Boon = {
+  name: "Broken Resolve",
+  type: OTHER,
+  element: WATER,
+  info: (value) => `Your [weak] effects are ${value} more potent`,
+  values: {
+    [COMMON]: { 1: "10%" },
+  },
+  prerequisites: [[raptureRing, passionDash, glamourGain]],
+};
+
+const sweetSurrender: Boon = {
+  name: "Sweet Surrender",
+  type: OTHER,
+  element: WATER,
+  info: (value) => `[weak]-afflicted foes take ${value} more damage`,
+  values: {
+    [COMMON]: { 1: "10%" },
+  },
+  prerequisites: [[raptureRing, passionDash, glamourGain]],
+};
+
 const burningDesire: Boon = {
   name: "Burning Desire",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `Up to +12 Lone Shades appear in Locations. Sprint into them to launch a fiery blast for ${value} damage`,
   values: {
     [DUO]: { 1: 160 },
   },
+  prerequisites: [
+    [raptureRing, passionDash, glamourGain],
+    [smolderRing, sootSprint, hearthGain],
+  ],
+};
+
+const romanticSpark: Boon = {
+  name: "Romantic Spark",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `If you Sprint into [blitz]-afflicted foes, the effect actives immediately and is ${value} stronger`,
+  values: {
+    [DUO]: { 1: "200%" },
+  },
+  prerequisites: [
+    [heavenFlourish, heavenStrike],
+    [passionDash, raptureRing, flutterFlourish, flutterStrike],
+  ],
 };
 
 const ecstaticObsession: Boon = {
@@ -142,16 +236,84 @@ const ecstaticObsession: Boon = {
   values: {
     [LEGENDARY]: { 1: 3 },
   },
+  prerequisites: [
+    [brokenResolve, sweetSurrender],
+    [raptureRing, passionDash, glamourGain],
+    [flutterFlourish, flutterStrike],
+  ],
 };
 
 const islandGetaway: Boon = {
   name: "Island Getaway",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `You take ${value} less damage from nearby foes. Boons of Aphrodite treat all foes as nearby.`,
   values: {
     [DUO]: { 1: "15%" },
   },
+  prerequisites: [
+    [waveStrike, waveFlourish, geyserRing, breakerSprint],
+    [flutterStrike, flutterFlourish],
+  ],
+};
+
+const softCaress: Boon = {
+  name: "Soft Caress",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `The first time you would take damage in each Encounter, turn ${value} of the hit into healing`,
+  values: {
+    [DUO]: { 1: "75%" },
+  },
+  prerequisites: [
+    [raptureRing, passionDash, glamourGain],
+    [anvilRing, smithySprint, fixedGain],
+  ],
+};
+
+const sunnyDisposition: Boon = {
+  name: "Sunny Disposition",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) => `Whenever you create Heartthrobs, create ${value} more`,
+  values: {
+    [DUO]: { 1: 2 },
+  },
+  prerequisites: [
+    [heartBreaker],
+    [novaStrike, novaFlourish, lucidGain, solarRing],
+  ],
+};
+
+const heartyAppetite: Boon = {
+  name: "Hearty Appetite",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) => `You deal ${value} more damage per 100 max health`,
+  values: {
+    [DUO]: { 1: "10%" },
+  },
+  prerequisites: [
+    [plentifulForage, winterCoat],
+    [shamelessAttitude, lifeAffirmation, healthyRebound],
+  ],
+};
+
+const soulMate: Boon = {
+  name: "Soul Mate",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Foes with [hitch] take ${value} more damage and are [weak], but only 2 can be afflicted at a time.`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [swornStrike, swornFlourish, nexusSprint, nastyComeback],
+    [raptureRing, passionDash, glamourGain],
+  ],
 };
 
 const abilities = {
@@ -167,6 +329,12 @@ const abilities = {
   burningDesire,
   ecstaticObsession,
   islandGetaway,
+  softCaress,
+  sunnyDisposition,
+  heartyAppetite,
+  soulMate,
+  romanticSpark,
+  wispyWiles,
 };
 
 const base: God = {

--- a/src/data/gods/apollo.ts
+++ b/src/data/gods/apollo.ts
@@ -1,9 +1,31 @@
-import { COMMON, RARE, EPIC, LEGENDARY, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, GAIN, OTHER } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import {
+  ATTACK,
+  CAST,
+  DASH,
+  GAIN,
+  INFUSION,
+  OTHER,
+  SPECIAL,
+} from "./abilityTypes";
+import { heartBreaker } from "./aphrodite";
+import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
+import { AIR, COSMIC, FIRE } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
-import { AIR, FIRE, } from "./elements";
+import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
+import { bornGain, engagementRing, nexusSprint } from "./hera";
+import {
+  burntOffering,
+  flameFlourish,
+  flameStrike,
+  flammableCoating,
+  hearthGain,
+  smolderRing,
+} from "./hestia";
+import { breakerSprint, fluidGain } from "./poseidon";
+import { COMMON, DUO, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
+import { heavenFlourish, heavenStrike, thunderSprint } from "./zeus";
 
 const info = "Apollo, God of Light and Sun";
 
@@ -13,11 +35,13 @@ const attack: Boon = {
   element: AIR,
   info: (value) => `Your Attacks deal ${value} more damage in a larger area`,
   values: {
-    [COMMON]: { 1: "40%", },
+    [COMMON]: { 1: "40%" },
     [RARE]: { 1: "50%", 4: "70%" },
     [EPIC]: { 1: "60%", 2: "70%", 4: "80%" },
   },
 };
+
+export const novaStrike: Boon = attack;
 
 const special: Boon = {
   name: "Nova Flourish",
@@ -42,6 +66,8 @@ const special: Boon = {
   },
 };
 
+export const novaFlourish: Boon = special;
+
 const cast: Boon = {
   name: "Solar Ring",
   type: CAST,
@@ -60,6 +86,8 @@ const cast: Boon = {
   },
 };
 
+export const solarRing: Boon = cast;
+
 const gain: Boon = {
   name: "Lucid Gain",
   type: GAIN,
@@ -67,17 +95,21 @@ const gain: Boon = {
   info: (value) =>
     `While standing in your Casts, gradually restore ${value} mana per second`,
   values: {
-    [COMMON]: { 1: 12, },
-    [RARE]: { 1: 18, 2: 24, },
+    [COMMON]: { 1: 12 },
+    [RARE]: { 1: 18, 2: 24 },
   },
 };
+
+export const lucidGain: Boon = gain;
 
 const dash: Boon = {
   name: "Blinding Sprint",
   type: DASH,
+  element: FIRE,
   info: (value) =>
     `Your Sprint is ${value} faster and inflicts [daze] on nearby foes`,
   values: {
+    [COMMON]: { 1: "15%" },
     [RARE]: {
       1: "40%",
     },
@@ -88,9 +120,12 @@ const dash: Boon = {
   },
 };
 
+export const blindingSprint: Boon = dash;
+
 const extraDose: Boon = {
   name: "Extra Dose",
   type: OTHER,
+  element: FIRE,
   info: (value) => `Your Attack has a ${value} chance to hit 2 times`,
   values: {
     [COMMON]: { 1: "5%", 2: "8%" },
@@ -98,30 +133,33 @@ const extraDose: Boon = {
   },
 };
 
-const superNova: Boon = {
+export const superNova: Boon = {
   name: "Super Nova",
   type: OTHER,
+  element: AIR,
   info: (value) => `Your Casts expand in size by ${value} until they expire`,
   values: {
-    [COMMON]: { 1: "40%", 2: "50%", },
-    [RARE]: { 1: "50%", 2: "60%", 3: "68%", 5: "78%", },
-    [EPIC]: { 1: "60%", 2: "70%", },
+    [COMMON]: { 1: "40%", 2: "50%" },
+    [RARE]: { 1: "50%", 2: "60%", 3: "68%", 5: "78%" },
+    [EPIC]: { 1: "60%", 2: "70%" },
   },
 };
 
 const lightSmite: Boon = {
   name: "Light Smite",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `After you take damage, your foes takes ${value} damage and you inflict Daze on all foes`,
   values: {
+    [COMMON]: { 1: 50 },
     [RARE]: { 1: 75 },
   },
 };
 
 const selfHealing: Boon = {
   name: `Self Healing`,
-  type: OTHER,
+  type: INFUSION,
   info: (value) =>
     `While you have at least 3 [fire] boons, whenever you take damage, restore ${value} of the damage taken`,
   values: {
@@ -135,51 +173,107 @@ const perfectImage: Boon = {
   element: AIR,
   info: (value) =>
     `In each encounter, you deal ${value} more damage until you take damage`,
-  values: { [RARE]: { 1: "15%" } },
+  values: { [COMMON]: { 1: "10%" }, [RARE]: { 1: "15%" } },
 };
 
 const dazzlingDisplay: Boon = {
   name: "Dazzling Display",
   type: OTHER,
+  element: FIRE,
   info: (value) => `Your Attacks have a ${value} chance to inflict [daze]`,
   values: {
+    [COMMON]: { 1: "10%" },
     [RARE]: { 1: "15%" },
   },
+  prerequisites: [[novaStrike]],
 };
 
 const backBurner: Boon = {
   name: "Back Burner",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `Foes with [daze] take more ${value} more damage if struck from behind`,
   values: {
     [COMMON]: { 1: "50%" },
   },
+  prerequisites: [[blindingSprint, lightSmite, dazzlingDisplay]],
 };
 
 const criticalMiss: Boon = {
   name: "Critical Miss",
   type: OTHER,
+  element: AIR,
   info: (value) =>
     `Foes take ${value} damage whenever [daze] causes them to miss`,
   values: {
+    [COMMON]: { 1: 100 },
     [RARE]: { 1: 150 },
   },
+  prerequisites: [[blindingSprint, lightSmite, dazzlingDisplay]],
+};
+
+const exceptionalTalent: Boon = {
+  name: "Exceptional Talent",
+  type: OTHER,
+  element: AIR,
+  info: (value) =>
+    `Your [omega] Attack and [omega] Special fire 2 times, but use +${value} [mana]`,
+  values: {
+    [LEGENDARY]: { 1: 20 },
+  },
+  prerequisites: [
+    [novaStrike, novaFlourish],
+    [solarRing, lucidGain],
+    [extraDose, superNova],
+  ],
+};
+
+const gloriousDisaster: Boon = {
+  name: "Glorious Disaster",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `You can Channel +30 [mana] into your [omega] Cast to repeatedly strike foes for ${value} bolt damage every 0.13 seconds`,
+  values: {
+    [LEGENDARY]: { 1: 50 },
+  },
+  prerequisites: [[solarRing], [heavenStrike, heavenFlourish, thunderSprint]],
+};
+
+const torrentialDownpour: Boon = {
+  name: "Torrential Downpour",
+  type: OTHER,
+  info: (value) =>
+    `Each time you use your [omega] Cast in an Encounter, it gets ${value} stronger but also uses +5 [mana]`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [solarRing, blindingSprint, lucidGain],
+    [arcticRing, frigidSprint, tranquilGain],
+  ],
 };
 
 const stellarSlam: Boon = {
   name: "Stellar Slam",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `Your blast effects from Hephaestus deal damage in a ${value} larger area`,
   values: {
     [DUO]: { 1: "50%" },
   },
+  prerequisites: [
+    [novaStrike, novaFlourish, superNova],
+    [volcanicFlourish, volcanicStrike, smithySprint],
+  ],
 };
 
 const phoenixSkin: Boon = {
   name: "Phoenix Skin",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `Give up -100 max health. If you do not take or deal damage for 3 seconds, rapidly restore ${value} health/sec`,
   values: {
@@ -187,6 +281,52 @@ const phoenixSkin: Boon = {
       1: 3,
     },
   },
+  prerequisites: [
+    [novaStrike, novaFlourish, lucidGain],
+    [flameStrike, flameFlourish, smolderRing],
+    [burntOffering, flammableCoating, hearthGain],
+  ],
+};
+
+const sunnyDisposition: Boon = {
+  name: "Sunny Disposition",
+  type: OTHER,
+  info: (value) => `Whenever you create Heartthrobs, create ${value} more`,
+  values: {
+    [DUO]: { 1: 2 },
+  },
+  prerequisites: [
+    [heartBreaker],
+    [novaStrike, novaFlourish, lucidGain, solarRing],
+  ],
+};
+
+const beachBall: Boon = {
+  name: "Beach Ball",
+  type: OTHER,
+  info: (value) =>
+    `Your Sprint creates a water sphere behind you. After you stop, it surges ahead and bursts for ${value} damage`,
+  values: {
+    [DUO]: { 1: 140 },
+  },
+  prerequisites: [
+    [blindingSprint, lucidGain],
+    [breakerSprint, fluidGain],
+  ],
+};
+
+const sunWorshiper: Boon = {
+  name: "Sun Worshiper",
+  type: OTHER,
+  info: (value) =>
+    `In each Encounter, the first foe you slay returns to fight for you dealing ${value} of its normal damage`,
+  values: {
+    [DUO]: { 1: "200%" },
+  },
+  prerequisites: [
+    [engagementRing, nexusSprint, bornGain],
+    [solarRing, blindingSprint, lucidGain],
+  ],
 };
 
 const abilities = {
@@ -205,6 +345,12 @@ const abilities = {
   stellarSlam,
   lightSmite,
   phoenixSkin,
+  exceptionalTalent,
+  gloriousDisaster,
+  torrentialDownpour,
+  sunnyDisposition,
+  beachBall,
+  sunWorshiper,
 };
 
 const base: God = {

--- a/src/data/gods/artemis.ts
+++ b/src/data/gods/artemis.ts
@@ -1,56 +1,17 @@
-import { COMMON, RARE, EPIC, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, OTHER } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import { CAST, DASH, OTHER } from "./abilityTypes";
+import { AIR, EARTH } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
-import { EARTH, AIR, } from "./elements";
+import { COMMON, EPIC, RARE } from "./rarities";
 
 const info =
   "Artemis, Goddess of the Hunt. Her powers cause critical hits and create seeking projectiles.";
 
-const attack: Boon = {
-  name: "Unknown",
-  type: ATTACK,
-  info: (value) => `Unknown`,
-  values: {
-    [COMMON]: {
-      1: "20%",
-    },
-    [RARE]: {
-      1: `${20 * 1.3}-${20 * 1.5}`,
-    },
-    [EPIC]: {
-      1: `${20 * 1.8}-${20 * 2}`,
-    },
-    [HEROIC]: {
-      1: `${20 * 2.3}-${20 * 2.5}`,
-    },
-  },
-};
-
-const special: Boon = {
-  name: "Unknown",
-  type: SPECIAL,
-  info: (value) => `Unknown`,
-  values: {
-    [COMMON]: {
-      1: "40%",
-    },
-    [RARE]: {
-      1: `${40 * 1.3}-${40 * 1.5}`,
-    },
-    [EPIC]: {
-      1: `${40 * 1.8}-${40 * 2}`,
-    },
-    [HEROIC]: {
-      1: `${40 * 2.3}-${40 * 2.5}`,
-    },
-  },
-};
-
-const cast: Boon = {
+const easyShot: Boon = {
   name: "Easy Shot",
   type: CAST,
+  element: AIR,
   info: (value) =>
     `A piercing arrow dealing ${value} damage fires toward any foe damage by your [omega] Cast`,
   values: {
@@ -70,7 +31,7 @@ const huntersFlare: Boon = {
   },
 };
 
-const dash: Boon = {
+const silverStreak: Boon = {
   name: "Silver Streak",
   type: DASH,
   element: AIR,
@@ -89,6 +50,7 @@ const dash: Boon = {
 const lethalSnare: Boon = {
   name: "Lethal Snare",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Foes in your Casts have an ${value} chance to take Critical damage from your Attacks`,
   values: {
@@ -111,9 +73,11 @@ const supportFire: Boon = {
 const deathWarrant: Boon = {
   name: "Death Warrant",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `A random foe becomes [marked] every ${value} seconds. If it takes Critical damage, this repeats.`,
   values: {
+    [COMMON]: { 1: 20 },
     [RARE]: { 1: 18 },
   },
 };
@@ -125,6 +89,7 @@ const firstBlood: Boon = {
   info: (value) =>
     `Foes with at least 80% health or 80% armor have a ${value} chance to take Critical damage`,
   values: {
+    [COMMON]: { 1: "10%" },
     [RARE]: { 1: "15%" },
     [EPIC]: { 1: "20%" },
   },
@@ -133,27 +98,15 @@ const firstBlood: Boon = {
 const pressurePoints: Boon = {
   name: "Pressure Points",
   type: OTHER,
+  element: EARTH,
   info: (value) => `Any damage you deal has a ${value} chance to be Critical`,
   values: {
+    [COMMON]: { 1: "3%" },
     [RARE]: { 1: "4%" },
   },
 };
 
-const easyShot: Boon = {
-  name: "Easy Shot",
-  type: OTHER,
-  info: (value) =>
-    `A piercing arrow fires toward any foe damage by your [omega] Cast for ${value} damage`,
-  values: {
-    [RARE]: { 1: 30 },
-  },
-};
-
 const abilities = {
-  attack,
-  special,
-  dash,
-  cast,
   "support fire": supportFire,
   "lethal snare": lethalSnare,
   "hunter's flare": huntersFlare,
@@ -161,6 +114,7 @@ const abilities = {
   firstBlood,
   pressurePoints,
   easyShot,
+  silverStreak,
 };
 
 const base: God = {

--- a/src/data/gods/demeter.ts
+++ b/src/data/gods/demeter.ts
@@ -1,19 +1,38 @@
-import { COMMON, RARE, EPIC, LEGENDARY, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, OTHER } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
+import {
+  healthyRebound,
+  lifeAffirmation,
+  shamelessAttitude,
+} from "./aphrodite";
+import { blindingSprint, lucidGain, solarRing } from "./apollo";
+import { COSMIC, EARTH, WATER } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
+import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
+import { bornGain, engagementRing, nexusSprint } from "./hera";
+import { flameFlourish, flameStrike } from "./hestia";
+import {
+  breakerSprint,
+  doubleUp,
+  fluidGain,
+  oceansBounty,
+  sunkenTreasure,
+} from "./poseidon";
+import { COMMON, DUO, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
+import { heavenFlourish, heavenStrike } from "./zeus";
 
 const info = "Demeter, Goddess of Seasons. Her abilities slows enemies.";
 
 const attack: Boon = {
   name: "Ice Strike",
   type: ATTACK,
+  element: WATER,
   info: (value) =>
-    `Your Attacks deals ${value} additional damage and apply [freeze]`,
+    `Your Attacks deals ${value} additional damage and inflicts [freeze]`,
   values: {
     [COMMON]: {
-      1: "10%",
+      1: "30%",
     },
     [RARE]: {
       1: "45%",
@@ -21,9 +40,12 @@ const attack: Boon = {
   },
 };
 
+export const iceStrike: Boon = attack;
+
 const special: Boon = {
   name: "Ice Flourish",
   type: SPECIAL,
+  element: WATER,
   info: (value) =>
     `Your Specials deal ${value} more damage and inflict [freeze]`,
   values: {
@@ -38,11 +60,14 @@ const special: Boon = {
   },
 };
 
+export const iceFlourish: Boon = special;
+
 const cast: Boon = {
   name: "Arctic Ring",
   type: CAST,
+  element: WATER,
   info: (value) =>
-    `Your Casts repeatedly deal ${value} damage in the area and inflict Freeze`,
+    `Your Casts repeatedly deal ${value} damage in the area and inflict [freeze]`,
   values: {
     [COMMON]: {
       1: 10,
@@ -54,10 +79,12 @@ const cast: Boon = {
     },
   },
 };
+export const arcticRing: Boon = cast;
 
-const tranquilGain: Boon = {
+export const tranquilGain: Boon = {
   name: "Tranquil Gain",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `After remaining inactive for 1 second, rapidly restore ${value} [mana]/second until you act`,
   values: {
@@ -67,40 +94,38 @@ const tranquilGain: Boon = {
 };
 
 const dash: Boon = {
-  name: "Unknown",
+  name: "Frigid Sprint",
   type: DASH,
-  info: (value) => `Unknown`,
+  element: WATER,
+  info: (value) =>
+    `Your Sprint forms a Cyclone around you that lingers after you stop dealing ${value} every 0.25 seconds.`,
   values: {
     [COMMON]: {
-      1: 15,
-    },
-    [RARE]: {
-      1: 22.5,
-    },
-    [EPIC]: {
-      1: 30,
-    },
-    [HEROIC]: {
-      1: 37.5,
+      1: 4,
     },
   },
 };
 
+export const frigidSprint: Boon = dash;
+
 const weedKiller: Boon = {
   name: "Weed Killer",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Your [omega] Attack deals ${value} more damage, but uses 10 more [mana]`,
   values: {
+    [COMMON]: { 1: "50%" },
     [RARE]: {
       1: "75%",
     },
   },
 };
 
-const rareCrop: Boon = {
+export const rareCrop: Boon = {
   name: "Rare Crop",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `${value} of your boons randomly become common, then gain rarity every 3 encounters.`,
   values: {
@@ -122,9 +147,11 @@ const rareCrop: Boon = {
 const galeForce: Boon = {
   name: "Gale Force",
   type: OTHER,
+  element: WATER,
   info: (value) =>
     `Your Casts also create a Cyclone at the binding circle dealing ${value} damage rapidly.`,
   values: {
+    [COMMON]: { 1: 4 },
     [EPIC]: {
       1: 12,
       2: 14,
@@ -132,12 +159,14 @@ const galeForce: Boon = {
   },
 };
 
-const plentifulForage: Boon = {
+export const plentifulForage: Boon = {
   name: `Plentiful Forage`,
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Whenever you gather plants, seeds, or mushrooms gain ${value} max health. Receive 1 mystery seed now.`,
   values: {
+    [COMMON]: { 1: 5 },
     [RARE]: {
       1: 8,
     },
@@ -146,46 +175,169 @@ const plentifulForage: Boon = {
 
 const coarseGrit: Boon = {
   name: `Coarse Grit`,
-  type: OTHER,
+  type: INFUSION,
   info: (value) =>
     `While you have at least 6 [earth] boons, you cannot take more than ${value} damage per hit`,
   values: {
-    [EPIC]: {
+    [COMMON]: {
       1: 15,
     },
   },
 };
 
-const winterCoat: Boon = {
+export const winterCoat: Boon = {
   name: `Winter Coat`,
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `After you enter a Location, Prime ${value} [mana] a barrier that absorbs 1 instance of damage`,
   values: {
+    [COMMON]: { 1: 20 },
     [RARE]: {
       1: 15,
     },
   },
 };
 
-const roomTemperature: Boon = {
-  name: "Room Temperature",
+const localClimate: Boon = {
+  name: "Local Climate",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
-    `Your blast effects from Hephaestus clear [freeze], so you [freeze] foes again right away`,
+    `Your [omega] cast deals ${value} bonus damage and follows you, even as you start to Channel it`,
   values: {
-    [RARE]: { 1: 50 },
+    [COMMON]: { 1: "20%" },
   },
 };
 
-const coldStorage: Boon = {
+const roomTemperature: Boon = {
+  name: "Room Temperature",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your blast effects from Hephaestus clear [freeze], so you [freeze] foes again right away.`,
+  values: {
+    [DUO]: { 1: 0 },
+  },
+  prerequisites: [
+    [volcanicFlourish, volcanicStrike, smithySprint],
+    [iceStrike, iceFlourish],
+  ],
+};
+
+export const coldStorage: Boon = {
   name: "Cold Storage",
   type: OTHER,
+  element: WATER,
   info: (value) => `Your [freeze] effects last ${value} seconds longer`,
   values: {
     [COMMON]: { 1: 2 },
   },
+  prerequisites: [[iceStrike, iceFlourish]],
 };
+
+const winterHarvest: Boon = {
+  name: "Winter Harvest",
+  type: OTHER,
+  element: EARTH,
+  info: (value) =>
+    `[freeze]-afflicted foes shatter at 10% health, dealing ${value} damage in the area`,
+  values: {
+    [LEGENDARY]: { 1: 100 },
+  },
+  prerequisites: [
+    [iceStrike, iceFlourish],
+    [plentifulForage, winterCoat],
+    [weedKiller, coldStorage],
+  ],
+};
+
+const torrentialDownpour: Boon = {
+  name: "Torrential Downpour",
+  type: OTHER,
+  info: (value) =>
+    `Each time you use your [omega] Cast in an Encounter, it gets ${value} stronger but also uses +5 [mana]`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [solarRing, blindingSprint, lucidGain],
+    [arcticRing, frigidSprint, tranquilGain],
+  ],
+};
+
+const freezerBurn: Boon = {
+  name: "Freezer Burn",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Whenever you inflict [freeze], amplify any [scorch] effects already on the foe by ${value}`,
+  values: {
+    [DUO]: { 1: "100%" },
+  },
+  prerequisites: [
+    [iceStrike, iceFlourish],
+    [flameStrike, flameFlourish],
+  ],
+};
+
+const apocalypticStorm: Boon = {
+  name: "Apocalyptic Storm",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your [blitz] effects last ${value} seconds longer, and active against all [blitz]-afflicted foes at once`,
+  values: {
+    [DUO]: { 1: 8 },
+  },
+  prerequisites: [
+    [iceStrike, iceFlourish, arcticRing, frigidSprint],
+    [heavenStrike, heavenFlourish],
+  ],
+};
+
+const naturalSelection: Boon = {
+  name: "Natural Selection",
+  type: OTHER,
+  info: (value) =>
+    `Location Rewards exclude max health, max [mana], and gold. Boon are ${value} more likely to be Rare or better`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [fluidGain, breakerSprint, oceansBounty, sunkenTreasure, doubleUp],
+    [tranquilGain, frigidSprint, winterCoat, coldStorage, rareCrop],
+  ],
+};
+
+const cherishedHeirloom: Boon = {
+  name: "Cherished Heirloom",
+  type: OTHER,
+  info: (value) =>
+    `Most other Keepsakes you equip are ${value} ranks strong this night (if possible)`,
+  values: {
+    [DUO]: { 1: 1 },
+  },
+  prerequisites: [
+    [nexusSprint, engagementRing, bornGain],
+    [arcticRing, frigidSprint, tranquilGain],
+  ],
+};
+
+const heartyAppetite: Boon = {
+  name: "Hearty Appetite",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) => `You deal ${value} more damage per 100 max health`,
+  values: {
+    [DUO]: { 1: "10%" },
+  },
+  prerequisites: [
+    [plentifulForage, winterCoat],
+    [shamelessAttitude, lifeAffirmation, healthyRebound],
+  ],
+};
+
 const abilities = {
   attack,
   special,
@@ -200,6 +352,14 @@ const abilities = {
   winterCoat,
   roomTemperature,
   coldStorage,
+  localClimate,
+  winterHarvest,
+  torrentialDownpour,
+  freezerBurn,
+  apocalypticStorm,
+  naturalSelection,
+  cherishedHeirloom,
+  heartyAppetite,
 };
 
 const base: God = {

--- a/src/data/gods/god.ts
+++ b/src/data/gods/god.ts
@@ -12,6 +12,7 @@ export type Boon = {
   element?: BoonElement;
   info: (value: string) => string;
   values: BoonValues;
+  prerequisites?: Array<Array<Boon>>;
 };
 
 export type God = {

--- a/src/data/gods/hephaestus.ts
+++ b/src/data/gods/hephaestus.ts
@@ -1,22 +1,34 @@
-import { COMMON, RARE, EPIC, LEGENDARY, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, OTHER } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
+import { glamourGain, passionDash, raptureRing } from "./aphrodite";
+import { novaFlourish, novaStrike, superNova } from "./apollo";
+import { iceFlourish, iceStrike } from "./demeter";
+import { COSMIC, EARTH, FIRE } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
+import { bornGain, braveFace, keenIntuition, nastyComeback } from "./hera";
+import { flameFlourish, flameStrike, smolderRing } from "./hestia";
+import { geyserRing } from "./poseidon";
+import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
+import { staticShock } from "./zeus";
 
 const info = "Hephaestus, God of the Forge";
 
 const attack: Boon = {
   name: "Volcanic Strike",
   type: ATTACK,
+  element: FIRE,
   info: (value) =>
     `Your Attacks occasionally create a blast that deals 200 damage. Recharges after ${value} seconds`,
-  values: { [RARE]: { 2: 8, 5: 5 } },
+  values: { [COMMON]: { 1: 12 }, [RARE]: { 2: 8, 5: 5 } },
 };
+
+export const volcanicStrike: Boon = attack;
 
 const special: Boon = {
   name: "Volcanic Flourish",
   type: SPECIAL,
+  element: FIRE,
   info: (value) =>
     `Your Special occasionally creates a blast that deals 400 damage in the area. Recharges after ${value} seconds`,
   values: {
@@ -29,21 +41,28 @@ const special: Boon = {
   },
 };
 
+export const volcanicFlourish: Boon = special;
+
 const cast: Boon = {
   name: "Anvil Ring",
   type: CAST,
+  element: EARTH,
   info: (value) =>
     `Your Casts deal ${value} damage 3 times in succession, but in a smaller area`,
   values: {
+    [COMMON]: { 1: 50 },
     [RARE]: {
       1: 70,
     },
   },
 };
 
-const fixedGain: Boon = {
+export const anvilRing: Boon = cast;
+
+export const fixedGain: Boon = {
   name: "Fixed Gain",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `You take -10% damage, and restore ${value} [mana] whenever you take damage`,
   values: {
@@ -54,21 +73,30 @@ const fixedGain: Boon = {
 const dash: Boon = {
   name: "Smithy Sprint",
   type: DASH,
+  element: FIRE,
   info: (value) =>
     `After you Sprint for 1 second, use 10 [mana] to create a blast for ${value} damage to nearby foes`,
   values: {
-    [RARE]: {
-      1: "40%",
-    },
-    [EPIC]: {
-      1: "50%",
-    },
+    [COMMON]: { 1: 200 },
   },
 };
 
-const toughTrade: Boon = {
+export const smithySprint: Boon = dash;
+
+const martialArt: Boon = {
+  name: "Martial Art",
+  type: INFUSION,
+  info: (value) =>
+    `After you hit with an Attack or Special, your next Attack or Special deals ${value} more damage`,
+  values: {
+    [RARE]: { 1: "50%" },
+  },
+};
+
+export const toughTrade: Boon = {
   name: "Tough Trade",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `If you take damage during your Attacks and Specials, they are ${value} stronger if they hit.`,
   values: {
@@ -80,26 +108,32 @@ const toughTrade: Boon = {
 const furnaceBlast: Boon = {
   name: "Furnace Blast",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `Your blast effects from Hephaestus also inflict ${value} [vent] damage on foes.`,
   values: {
+    [COMMON]: { 1: 300 },
     [RARE]: { 1: "400" },
   },
+  prerequisites: [[volcanicStrike, volcanicFlourish, smithySprint]],
 };
 
-const heavyMetal: Boon = {
+export const heavyMetal: Boon = {
   name: "Heavy Metal",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Gain some ${value} [armor]. Foe's attacks cannot knock you away.`,
   values: {
+    [COMMON]: { 1: 50 },
     [RARE]: { 1: "75" },
   },
 };
 
-const mintCondition: Boon = {
+export const mintCondition: Boon = {
   name: "Mint Condition",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `At the start of each Encounter you are impervious for ${value} seconds`,
   values: {
@@ -107,53 +141,160 @@ const mintCondition: Boon = {
   },
 };
 
-const uncannyFortitude: Boon = {
+export const trustyShield: Boon = {
+  name: "Trusty Shield",
+  type: OTHER,
+  element: EARTH,
+  info: (value) =>
+    `After you enter a Location, Prime 30 [mana] to gain ${value} Armor until the next Location`,
+  values: {
+    [COMMON]: { 1: 10 },
+  },
+};
+
+export const uncannyFortitude: Boon = {
   name: "Uncanny Fortitude",
   type: OTHER,
+  element: EARTH,
   info: (value) => `Gain ${value} max health, based on your [mana] limit`,
   values: {
     [COMMON]: { 1: "20%" },
   },
 };
 
+const fineTuning: Boon = {
+  name: "Fine Tuning",
+  type: OTHER,
+  element: EARTH,
+  info: (value) =>
+    `Your Aspect of the Nocturnal Arms is ${value} ranks stronger`,
+  values: {
+    [LEGENDARY]: { 1: 1 },
+  },
+};
+
 const roomTemperature: Boon = {
   name: "Room Temperature",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
-    `Your blast effects from Hephaestus clear [freeze], so you [freeze] foes again right away`,
+    `Your blast effects from Hephaestus clear [freeze], so you [freeze] foes again right away.`,
   values: {
-    [RARE]: { 1: 50 },
+    [DUO]: { 1: 0 },
   },
+  prerequisites: [
+    [volcanicFlourish, volcanicStrike, smithySprint],
+    [iceStrike, iceFlourish],
+  ],
 };
 
 const chainReaction: Boon = {
   name: "Chain Reaction",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `If you use your blast effects from Hephaestus just within ${value} seconds of them recharging, they fire 2 times`,
   values: {
     [DUO]: { 1: 0.85 },
   },
-};
-
-const stellarSlam: Boon = {
-  name: "Stellar Slam",
-  type: OTHER,
-  info: (value) =>
-    `Your blast effects from Hephaestus deal damage in a ${value} larger area`,
-  values: {
-    [DUO]: { 1: "50%" },
-  },
+  prerequisites: [
+    [volcanicFlourish, volcanicStrike],
+    [flameStrike, flameFlourish, smolderRing],
+  ],
 };
 
 const moltenTouch: Boon = {
   name: "Molten Touch",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `Your Attacks and Specials deal ${value} bonus damage to Armor`,
   values: {
+    [COMMON]: { 1: "20%" },
     [EPIC]: { 1: "40%", 4: "75%" },
   },
+};
+
+const spitefulStrength: Boon = {
+  name: "Spiteful Strength",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your Attacks and Specials deal ${value} more damage while not empowered by Boons`,
+  values: {
+    [DUO]: "200%",
+  },
+  prerequisites: [
+    [braveFace, nastyComeback, keenIntuition, bornGain],
+    [
+      trustyShield,
+      mintCondition,
+      heavyMetal,
+      toughTrade,
+      uncannyFortitude,
+      fixedGain,
+    ],
+  ],
+};
+
+const softCaress: Boon = {
+  name: "Soft Caress",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `The first time you would take damage in each Encounter, turn ${value} of the hit into healing`,
+  values: {
+    [DUO]: { 1: "75%" },
+  },
+  prerequisites: [
+    [raptureRing, passionDash, glamourGain],
+    [anvilRing, smithySprint, fixedGain],
+  ],
+};
+
+const stellarSlam: Boon = {
+  name: "Stellar Slam",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your blast effects from Hephaestus deal damage in a ${value} larger area`,
+  values: {
+    [DUO]: { 1: "50%" },
+  },
+  prerequisites: [
+    [novaStrike, novaFlourish, superNova],
+    [volcanicFlourish, volcanicStrike, smithySprint],
+  ],
+};
+
+const seismicHammer: Boon = {
+  name: "Seismic Hammer",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your [omega] cast occasionally creates a blast that deals 500 damage in the area. Recharges after ${value} seconds`,
+  values: {
+    [DUO]: { 1: 15 },
+  },
+  prerequisites: [
+    [geyserRing],
+    [volcanicStrike, volcanicFlourish, smithySprint],
+  ],
+};
+
+const masterConductor: Boon = {
+  name: "Master Conductor",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your chain-lightning deals ${value} more damage per bounce and can bounce to you`,
+  values: {
+    [DUO]: { 1: "15%" },
+  },
+  prerequisites: [
+    [staticShock],
+    [fixedGain, trustyShield, heavyMetal, mintCondition, toughTrade],
+  ],
 };
 
 const abilities = {
@@ -171,6 +312,12 @@ const abilities = {
   chainReaction,
   stellarSlam,
   moltenTouch,
+  spitefulStrength,
+  softCaress,
+  martialArt,
+  fineTuning,
+  seismicHammer,
+  masterConductor,
 };
 
 const base: God = {

--- a/src/data/gods/hera.ts
+++ b/src/data/gods/hera.ts
@@ -1,36 +1,72 @@
-import { COMMON, RARE, EPIC, LEGENDARY, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, OTHER } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import { ATTACK, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
+import { glamourGain, passionDash, raptureRing } from "./aphrodite";
+import { blindingSprint, lucidGain, solarRing } from "./apollo";
+import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
+import { COSMIC, EARTH } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
+import {
+  fixedGain,
+  heavyMetal,
+  mintCondition,
+  toughTrade,
+  trustyShield,
+  uncannyFortitude,
+} from "./hephaestus";
+import {
+  special as flameFlourish,
+  attack as flameStrike,
+  hearthGain,
+  cast as smolderRing,
+} from "./hestia";
+import {
+  breakerSprint,
+  doubleUp,
+  fluidGain,
+  geyserRing,
+  oceansBounty,
+} from "./poseidon";
+import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
+import {
+  heavenFlourish,
+  heavenStrike,
+  ionicGain,
+  stormRing,
+  thunderSprint,
+} from "./zeus";
 
 const info = "Hera, Queen of the Gods";
 
 const attack: Boon = {
   name: "Sworn Strike",
   type: ATTACK,
+  element: EARTH,
   info: (value) =>
     `Your Attacks deal more ${value} more damage and inflict [hitch]`,
   values: { [COMMON]: { 1: "50%" }, [RARE]: { 1: "60%" } },
 };
 
+export const swornStrike = attack;
+
 const special: Boon = {
   name: "Sworn Flourish",
   type: SPECIAL,
-  info: (value) => `Your Specials day ${value} more data and inflict [hitch]`,
+  element: EARTH,
+  info: (value) => `Your Specials day ${value} more damage and inflict [hitch]`,
   values: {
     [COMMON]: {
-      1: "20",
-    },
-    [RARE]: {
-      1: 18,
+      1: "60%",
     },
   },
 };
 
+export const swornFlourish = special;
+
 const dash: Boon = {
   name: "Nexus Sprint",
   type: DASH,
+  element: EARTH,
   info: (value) =>
     `Your Sprint inflicts [hitch] on nearby foes, which spreads to ${value} other foes near them`,
   values: {
@@ -43,9 +79,12 @@ const dash: Boon = {
   },
 };
 
-const bornGain: Boon = {
+export const nexusSprint = dash;
+
+export const bornGain: Boon = {
   name: "Born Gain",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Whenever you run out of [mana], Prime ${value} [mana] to restore all [mana] up to the reduced limit`,
   values: {
@@ -56,6 +95,7 @@ const bornGain: Boon = {
 const cast: Boon = {
   name: "Engagement Ring",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Your Casts last 200% longer and deal ${value} damage to every foe that joins the Encounter`,
   values: {
@@ -63,9 +103,22 @@ const cast: Boon = {
   },
 };
 
-const keenIntuition: Boon = {
+export const engagementRing = cast;
+
+const properUpbringing: Boon = {
+  name: "Proper Upbringing",
+  type: INFUSION,
+  info: (value) =>
+    `While you have at least 3 [earth], all your Common Boons gain ${value} Rarity`,
+  values: {
+    [COMMON]: { 1: "RARE" },
+  },
+};
+
+export const keenIntuition: Boon = {
   name: "Keen Intuition",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Whenever you use [omega] moves while you have 100% [mana], they deal ${value} more damage`,
   values: {
@@ -73,19 +126,10 @@ const keenIntuition: Boon = {
   },
 };
 
-const kingsRansom: Boon = {
-  name: "King's Ransom",
-  type: OTHER,
-  info: (value) =>
-    `Give up all your Boons of Hera. For each raise all of your Boons of Zeus by ${value} levels`,
-  values: {
-    [DUO]: { 1: 2 },
-  },
-};
-
 const familyTrade: Boon = {
   name: "Family Trade",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Any Sacrifice Boons you choose are ${value} levels stronger. One will be offered as soon as possible.`,
   values: {
@@ -93,19 +137,10 @@ const familyTrade: Boon = {
   },
 };
 
-const hereditaryBane: Boon = {
-  name: "Hereditary Bane",
-  type: OTHER,
-  info: (value) =>
-    `Your [hitch] effects deal ${value} more damage and last +5 seconds`,
-  values: {
-    [EPIC]: { 1: "20%", 2: "30%" },
-  },
-};
-
-const nastyComeback: Boon = {
+export const nastyComeback: Boon = {
   name: "Nasty Comeback",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `After you take damage, inflict your foe with [hitch] and deal ${value} damage in greater measure`,
   values: {
@@ -113,12 +148,27 @@ const nastyComeback: Boon = {
   },
 };
 
+const hereditaryBane: Boon = {
+  name: "Hereditary Bane",
+  type: OTHER,
+  element: EARTH,
+  info: (value) =>
+    `Your [hitch] effects deal ${value} more damage and last +5 seconds`,
+  values: {
+    [COMMON]: { 1: "10%" },
+    [EPIC]: { 1: "20%", 2: "30%" },
+  },
+  prerequisites: [[attack, special, dash, nastyComeback]],
+};
+
 const bridalGlow: Boon = {
   name: "Bridal Glow",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `${value} random Boons become Heroic, then lose Rarity every 7 Encounters`,
   values: {
+    [COMMON]: { 1: "2" },
     [RARE]: { 1: "2" },
   },
 };
@@ -126,6 +176,7 @@ const bridalGlow: Boon = {
 const uncommonGrace: Boon = {
   name: "Uncommon Grace",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `While none of your other Boons are Common, deal ${value} more damage`,
   values: {
@@ -136,11 +187,137 @@ const uncommonGrace: Boon = {
 const dyingWish: Boon = {
   name: "Dying Wish",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
-    `Whenever [hitch]-afflicted foes are slain, damage all over [hitch] afflicted foes for ${value}`,
+    `Whenever [hitch]-afflicted foes are slain, damage all other [hitch] afflicted foes for ${value}`,
   values: {
-    [COMMON]: "60",
+    [COMMON]: "40",
   },
+  prerequisites: [[attack, special, dash, nastyComeback]],
+};
+
+export const braveFace: Boon = {
+  name: "Brave Face",
+  type: OTHER,
+  element: EARTH,
+  info: (value) =>
+    `Automatically use ${value} magic to resist up to 50% of any damage`,
+  values: {
+    [LEGENDARY]: { 1: 5 },
+  },
+  prerequisites: [
+    [attack, special],
+    [bornGain, keenIntuition],
+    [hereditaryBane, dyingWish],
+  ],
+};
+
+const funeralPyre: Boon = {
+  name: "Funeral Pyre",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `While you Channel your [omega] moves, repeatedly inflict ${value} [scorch] on nearby foes`,
+  values: {
+    [DUO]: { 1: 90 },
+  },
+  prerequisites: [
+    [attack, special, cast, bornGain],
+    [flameStrike, flameFlourish, smolderRing, hearthGain],
+  ],
+};
+
+const spitefulStrength: Boon = {
+  name: "Spiteful Strength",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your Attacks and Specials deal ${value} more damage while not empowered by Boons`,
+  values: {
+    [DUO]: "200%",
+  },
+  prerequisites: [
+    [braveFace, nastyComeback, keenIntuition, bornGain],
+    [
+      trustyShield,
+      mintCondition,
+      heavyMetal,
+      toughTrade,
+      uncannyFortitude,
+      fixedGain,
+    ],
+  ],
+};
+
+const cherishedHeirloom: Boon = {
+  name: "Cherished Heirloom",
+  type: OTHER,
+  info: (value) =>
+    `Most other Keepsakes you equip are ${value} ranks strong this night (if possible)`,
+  values: {
+    [DUO]: { 1: 1 },
+  },
+  prerequisites: [
+    [dash, cast, bornGain],
+    [arcticRing, frigidSprint, tranquilGain],
+  ],
+};
+
+const soulMate: Boon = {
+  name: "Soul Mate",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Foes with [hitch] take ${value} more damage and are [weak], but only 2 can be afflicted at a time.`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [attack, special, dash, nastyComeback],
+    [raptureRing, passionDash, glamourGain],
+  ],
+};
+
+const goldenRule: Boon = {
+  name: "Golden Rule",
+  type: OTHER,
+  info: (value) => `You deal ${value} more damage per 100 gold you have`,
+  values: {
+    [DUO]: "5%",
+  },
+  prerequisites: [
+    [cast, dash, bornGain],
+    [geyserRing, breakerSprint, fluidGain],
+    [oceansBounty, doubleUp],
+  ],
+};
+
+const sunWorshiper: Boon = {
+  name: "Sun Worshiper",
+  type: OTHER,
+  info: (value) =>
+    `In each Encounter, the first foe you slay returns to fight for you dealing ${value} of its normal damage`,
+  values: {
+    [DUO]: { 1: "200%" },
+  },
+  prerequisites: [
+    [cast, dash, bornGain],
+    [solarRing, blindingSprint, lucidGain],
+  ],
+};
+
+const queensRansom: Boon = {
+  name: "Queen's Ransom",
+  type: OTHER,
+  info: (value) =>
+    `Give up all your Boons of Zeus. For each raise all of your Boons of Hera by ${value} levels`,
+  values: {
+    [DUO]: { 1: 3 },
+  },
+  prerequisites: [
+    [attack, special, dash, cast, bornGain],
+    [heavenStrike, heavenFlourish, stormRing, thunderSprint, ionicGain],
+  ],
 };
 
 const abilities = {
@@ -151,13 +328,21 @@ const abilities = {
   bornGain,
   engagementRing: cast,
   keenIntuition,
-  "king's ransom": kingsRansom,
   familyTrade,
   hereditaryBane,
   bridalGlow,
   uncommonGrace,
   dyingWish,
   nastyComeback,
+  braveFace,
+  funeralPyre,
+  spitefulStrength,
+  cherishedHeirloom,
+  soulMate,
+  goldenRule,
+  sunWorshiper,
+  queensRansom,
+  properUpbringing,
 };
 
 const base: God = {

--- a/src/data/gods/hermes.ts
+++ b/src/data/gods/hermes.ts
@@ -1,9 +1,9 @@
-import { COMMON, RARE, EPIC, LEGENDARY, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, OTHER } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
+import { AIR, EARTH, FIRE } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
-import { EARTH, AIR, } from "./elements";
+import { COMMON, EPIC, LEGENDARY, RARE } from "./rarities";
 
 const info =
   "Hermes, God of Speed and Commerce. His abilities increase your speed";
@@ -11,6 +11,7 @@ const info =
 const attack: Boon = {
   name: "Swift Strike",
   type: ATTACK,
+  element: EARTH,
   info: (value) => `Your Attack is ${value} faster`,
   values: {
     [COMMON]: {
@@ -51,6 +52,7 @@ const cast: Boon = {
 const dash: Boon = {
   name: "Nitro Boost",
   type: DASH,
+  element: FIRE,
   info: (value) =>
     `Your Sprint is 20% faster and gives you a barrier that ignores ${value} instance(s) of damage per encounter`,
   values: {
@@ -63,6 +65,7 @@ const dash: Boon = {
 const hardTarget: Boon = {
   name: "Hard Target",
   type: OTHER,
+  element: AIR,
   info: (value) => `Most foes' ranged shots are ${value} slower`,
   values: {
     [COMMON]: { 1: "-30%" },
@@ -85,6 +88,7 @@ const meanStreak: Boon = {
 const wittyRetort: Boon = {
   name: "Witty Retort",
   type: OTHER,
+  element: EARTH,
   info: (value) =>
     `Your Hex requires using less ${value} [mana] before it is ready`,
   values: {
@@ -106,9 +110,11 @@ const quickBuck: Boon = {
 const greaterEvasion: Boon = {
   name: "Greater Evasion",
   type: OTHER,
+  element: AIR,
   info: (value) =>
     `Whenever you are struck, you have a ${value} chance to Dodge any damage`,
   values: {
+    [COMMON]: { 1: "10%" },
     [RARE]: { 1: "15%" },
   },
 };
@@ -116,9 +122,43 @@ const greaterEvasion: Boon = {
 const savedBreath: Boon = {
   name: "Saved Breath",
   type: OTHER,
+  element: EARTH,
   info: (value) => `Your [omega] Cast uses ${value} less [mana]`,
   values: {
+    [COMMON]: { 1: "-50%" },
     [RARE]: { 1: "-60%" },
+  },
+};
+
+const tallOrder: Boon = {
+  name: "Tall Order",
+  type: INFUSION,
+  info: (value) =>
+    `WHile you have at least 2 of each [earth] [water] [air] [fire], you deal ${value} more damage`,
+  values: {
+    [COMMON]: { 1: "20%" },
+  },
+};
+
+const midnightOil: Boon = {
+  name: "Midnight Oil",
+  type: OTHER,
+  element: AIR,
+  info: (value) =>
+    `While your Hex is ready, you move and strike ${value} faster`,
+  values: {
+    [COMMON]: { 1: "15%" },
+  },
+};
+
+const closeCall: Boon = {
+  name: "Close Call",
+  type: OTHER,
+  element: AIR,
+  info: (value) =>
+    `Gain +1 use of Death Defiance that makes everything else move 90% slower for ${value} seconds`,
+  values: {
+    [LEGENDARY]: { 1: 8 },
   },
 };
 
@@ -133,6 +173,9 @@ const abilities = {
   quickBuck,
   greaterEvasion,
   savedBreath,
+  tallOrder,
+  midnightOil,
+  closeCall,
 };
 
 const base: God = {

--- a/src/data/gods/hestia.ts
+++ b/src/data/gods/hestia.ts
@@ -1,14 +1,23 @@
-import { COMMON, RARE, EPIC, LEGENDARY, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, OTHER } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
+import { glamourGain, passionDash, raptureRing } from "./aphrodite";
+import { lucidGain, novaFlourish, novaStrike } from "./apollo";
+import { iceFlourish, iceStrike } from "./demeter";
+import { COSMIC, FIRE } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
+import { volcanicFlourish, volcanicStrike } from "./hephaestus";
+import { bornGain, engagementRing, swornFlourish, swornStrike } from "./hera";
+import { slipperySlope } from "./poseidon";
+import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
+import { heavenFlourish, heavenStrike } from "./zeus";
 
 const info = "Goddess of flame";
 
-const attack: Boon = {
+export const attack: Boon = {
   name: "Flame Strike",
   type: ATTACK,
+  element: FIRE,
   info: (value) => `Your attacks inflict ${value} scorch damage`,
   values: {
     [COMMON]: {
@@ -21,39 +30,41 @@ const attack: Boon = {
   },
 };
 
-const special: Boon = {
+export const flameStrike = attack;
+
+export const special: Boon = {
   name: "Flame Flourish",
   type: SPECIAL,
+  element: FIRE,
   info: (value) => `Your Special inflicts ${value} [scorch] damage`,
   values: {
+    [COMMON]: { 1: 15 },
     [RARE]: { 1: 20, 2: 25 },
     [EPIC]: { 1: 25 },
   },
 };
 
-const cast: Boon = {
-  name: "Unknown",
+export const flameFlourish = special;
+
+export const cast: Boon = {
+  name: "Smolder Ring",
   type: CAST,
-  info: (value) => `Unknown`,
+  element: FIRE,
+  info: (value) =>
+    `Your Casts repeatedly inflict ${value} [scorch] per second on foes`,
   values: {
     [COMMON]: {
-      1: 90,
-    },
-    [RARE]: {
-      1: 99,
-    },
-    [EPIC]: {
-      1: 108,
-    },
-    [HEROIC]: {
-      1: 117,
+      1: 30,
     },
   },
 };
 
+export const smolderRing = cast;
+
 const dash: Boon = {
   name: "Soot Sprint",
   type: DASH,
+  element: FIRE,
   info: (value) =>
     `Your Sprint destroys most ranged shots near you, and inflicts ${value} [scorch] on foes that fired.`,
   values: {
@@ -67,69 +78,50 @@ const dash: Boon = {
   },
 };
 
-const hearthGain: Boon = {
+export const sootSprint = dash;
+
+export const hearthGain: Boon = {
   name: "Hearth Gain",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `Rapidly restore ${value} [mana] every second, but you have -20% less max health`,
   values: {
+    [COMMON]: {
+      1: 7,
+    },
     [RARE]: {
       1: 10,
     },
   },
 };
 
-const controlledBurn: Boon = {
+export const controlledBurn: Boon = {
   name: "Controlled Burn",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `Your [omega] Special also launches a fiery projectile that deals ${value} damage, but also uses +10 [mana]`,
   values: {
-    [RARE]: {
-      1: 10,
-    },
+    [COMMON]: { 1: 80 },
   },
 };
 
-const burntOffering: Boon = {
+export const burntOffering: Boon = {
   name: "Burnt Offering",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `Gain ${value} max health and max magic, but give up 1 boon selected by Hestia`,
   values: {
-    [RARE]: {
-      1: 10,
+    [COMMON]: {
+      1: 50,
     },
   },
 };
-
-const naturalGas: Boon = {
-  name: "Natural Gas",
-  type: OTHER,
-  info: (value) =>
-    `Whenever [scorch]-afflicted foes are slain, they damage nearby foes for ${value} damage`,
-  values: {
-    [EPIC]: {
-      1: 120,
-    },
-  },
-};
-
-const funeralPyre: Boon = {
-  name: "Funeral Pyre",
-  type: OTHER,
-  info: (value) =>
-    `While you Channel your [omega] Moves, repeatedly inflict ${value} [scorch] on nearby foes.`,
-  values: {
-    [DUO]: {
-      1: 90,
-    },
-  },
-};
-
 const slowCooker: Boon = {
   name: "Slow Cooker",
-  type: OTHER,
+  type: INFUSION,
   info: (value) =>
     `Your Attacks and Specials gain ${value} Power for each [fire] boon you have`,
   values: {
@@ -139,12 +131,14 @@ const slowCooker: Boon = {
   },
 };
 
-const glowingCoal: Boon = {
+export const glowingCoal: Boon = {
   name: "Glowing Coal",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `Hold Cast to aim a fiery projectile that explodes on impact for ${value} damage. The binding circle forms there.`,
   values: {
+    [COMMON]: { 1: 50 },
     [EPIC]: {
       1: 90,
       2: 110,
@@ -155,12 +149,60 @@ const glowingCoal: Boon = {
   },
 };
 
+export const spontaneousCombustion: Boon = {
+  name: "Spontaneous Combustion",
+  type: OTHER,
+  element: FIRE,
+  info: (value) =>
+    `Your [omega] special inflicts ${value} bonus [scorch] if foes are not afflicted`,
+  values: {
+    [COMMON]: { 1: 60 },
+  },
+};
+
+const naturalGas: Boon = {
+  name: "Natural Gas",
+  type: OTHER,
+  element: FIRE,
+  info: (value) =>
+    `Whenever [scorch]-afflicted foes are slain, they damage nearby foes for ${value} damage`,
+  values: {
+    [COMMON]: { 1: 60 },
+    [EPIC]: {
+      1: 120,
+    },
+  },
+  prerequisites: [
+    [flameFlourish, flameStrike, smolderRing, spontaneousCombustion],
+  ],
+};
+
+export const flammableCoating: Boon = {
+  name: "Flammable Coating",
+  type: OTHER,
+  element: FIRE,
+  info: (value) => `Your [scorch] effects deal ${value} bonus damage to Armor`,
+  values: {
+    [COMMON]: { 1: "100%" },
+    [EPIC]: {
+      1: "200%",
+    },
+  },
+  prerequisites: [
+    [flameFlourish, flameStrike, smolderRing, spontaneousCombustion],
+  ],
+};
+
 const fireExtinguisher: Boon = {
   name: "Fire Extinguisher",
   type: OTHER,
+  element: FIRE,
   info: (value) =>
     `Foes with at least 300 [scorch] take a burst of damage equal to ${value} their [scorch] that consumes the effect`,
   values: {
+    [COMMON]: {
+      1: "50%",
+    },
     [RARE]: {
       1: "62%",
     },
@@ -168,32 +210,30 @@ const fireExtinguisher: Boon = {
       1: "75%",
     },
   },
-};
-
-const flammableCoating: Boon = {
-  name: "Flammable Coating",
-  type: OTHER,
-  info: (value) => `Your [scorch] effects deal ${value} bonus damage to Armor`,
-  values: {
-    [EPIC]: {
-      1: "200%",
-    },
-  },
+  prerequisites: [
+    [flameFlourish, flameStrike, smolderRing, spontaneousCombustion],
+  ],
 };
 
 const chainReaction: Boon = {
   name: "Chain Reaction",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `If you use your blast effects from Hephaestus just within ${value} seconds of them recharging, they fire 2 times`,
   values: {
     [DUO]: { 1: 0.85 },
   },
+  prerequisites: [
+    [volcanicFlourish, volcanicStrike],
+    [flameStrike, flameFlourish, smolderRing],
+  ],
 };
 
 const phoenixSkin: Boon = {
   name: "Phoenix Skin",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `Give up -100 max health. If you do not take or deal damage for 3 seconds, rapidly restore ${value} health/sec`,
   values: {
@@ -201,27 +241,110 @@ const phoenixSkin: Boon = {
       1: 3,
     },
   },
+  prerequisites: [
+    [novaStrike, novaFlourish, lucidGain],
+    [flameStrike, flameFlourish, smolderRing],
+    [burntOffering, flammableCoating, hearthGain],
+  ],
 };
 
-const burningDesire: Boon = {
+const freezerBurn: Boon = {
+  name: "Freezer Burn",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Whenever you inflict [freeze], amplify any [scorch] effects already on the foe by ${value}`,
+  values: {
+    [DUO]: { 1: "100%" },
+  },
+  prerequisites: [
+    [iceStrike, iceFlourish],
+    [flameStrike, flameFlourish],
+  ],
+};
+
+export const burningDesire: Boon = {
   name: "Burning Desire",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `Up to +12 Lone Shades appear in Locations. Sprint into them to launch a fiery blast for ${value} damage`,
   values: {
     [DUO]: { 1: 160 },
   },
+  prerequisites: [
+    [raptureRing, passionDash, glamourGain],
+    [smolderRing, sootSprint, hearthGain],
+  ],
 };
 
 const pyroTechnique: Boon = {
   name: "Pyro Technique",
   type: OTHER,
+  element: FIRE,
   info: (value) => `Your [scorch] effects deal damage ${value} faster`,
   values: {
     [LEGENDARY]: {
       1: "100%",
     },
   },
+  prerequisites: [
+    [flameFlourish, flameStrike, smolderRing, spontaneousCombustion],
+    [naturalGas, flammableCoating],
+    [glowingCoal, controlledBurn],
+  ],
+};
+
+const funeralPyre: Boon = {
+  name: "Funeral Pyre",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `While you Channel your [omega] moves, repeatedly inflict ${value} [scorch] on nearby foes`,
+  values: {
+    [DUO]: { 1: 90 },
+  },
+  prerequisites: [
+    [swornStrike, swornFlourish, engagementRing, bornGain],
+    [flameStrike, flameFlourish, smolderRing, hearthGain],
+  ],
+};
+
+const thermalDynamics: Boon = {
+  name: "Thermal Dynamics",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your [blitz] effects also inflict ${value} [scorch] whenever they deal damage`,
+  values: {
+    [DUO]: { 1: 80 },
+  },
+  prerequisites: [
+    [heavenStrike, heavenFlourish],
+    [flameFlourish, flameStrike],
+  ],
+};
+
+const scaldingVapor: Boon = {
+  name: "Scalding Vapor",
+  type: OTHER,
+  info: (value) =>
+    `If foes with [slip] are struck with fire from Hestia, they are engulfed in [steam] that deals ${value} damage every 0.2 seconds`,
+  values: {
+    [DUO]: { 1: 25 },
+  },
+  prerequisites: [
+    [slipperySlope],
+    [
+      flameStrike,
+      flameFlourish,
+      smolderRing,
+      spontaneousCombustion,
+      burningDesire,
+      controlledBurn,
+      glowingCoal,
+    ],
+  ],
 };
 
 const abilities = {
@@ -242,6 +365,10 @@ const abilities = {
   phoenixSkin,
   burningDesire,
   pyroTechnique,
+  spontaneousCombustion,
+  freezerBurn,
+  scaldingVapor,
+  thermalDynamics,
 };
 
 const base: God = {

--- a/src/data/gods/poseidon.ts
+++ b/src/data/gods/poseidon.ts
@@ -1,18 +1,53 @@
-import { COMMON, RARE, EPIC, LEGENDARY, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, OTHER } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
+import { flutterFlourish, flutterStrike } from "./aphrodite";
+import { blindingSprint, lucidGain } from "./apollo";
+import {
+  coldStorage,
+  frigidSprint,
+  rareCrop,
+  tranquilGain,
+  winterCoat,
+} from "./demeter";
+import { COSMIC, WATER } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
-import { WATER } from "./elements";
+import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
+import { bornGain, nexusSprint, swornStrike } from "./hera";
+import {
+  burningDesire,
+  controlledBurn,
+  flameFlourish,
+  flameStrike,
+  glowingCoal,
+  smolderRing,
+  spontaneousCombustion,
+} from "./hestia";
+import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
+import {
+  divineVengeance,
+  heavenFlourish,
+  heavenStrike,
+  lightningLance,
+  stormRing,
+  thunderSprint,
+} from "./zeus";
 
 const info = "Poseidon, God of the Sea. His powers knock enemies away.";
 
 const attack: Boon = {
-  name: "Unknown",
+  name: "Wave Strike",
   type: ATTACK,
-  info: (value) => `Unknown`,
-  values: {},
+  info: (value) =>
+    `Your Attacks hit foes with a splash that knocks foes away and deals ${value} damage`,
+  values: {
+    [COMMON]: {
+      1: 15,
+    },
+  },
 };
+
+export const waveStrike: Boon = attack;
 
 const special: Boon = {
   name: "Wave Flourish",
@@ -33,6 +68,8 @@ const special: Boon = {
   },
 };
 
+export const waveFlourish: Boon = special;
+
 const cast: Boon = {
   name: "Geyser Ring",
   type: CAST,
@@ -49,6 +86,8 @@ const cast: Boon = {
     },
   },
 };
+
+export const geyserRing: Boon = cast;
 
 const dash: Boon = {
   name: "Breaker Sprint",
@@ -68,6 +107,8 @@ const dash: Boon = {
   },
 };
 
+export const breakerSprint: Boon = dash;
+
 const floodControl: Boon = {
   name: "Flood Control",
   type: OTHER,
@@ -75,26 +116,28 @@ const floodControl: Boon = {
   info: (value) =>
     `After you enter a Location, Prime 30 [mana] to reduce any damage you would take by ${value} per hit.`,
   values: {
+    [COMMON]: { 1: -2 },
     [RARE]: { 1: -3 },
   },
-}
+};
 
 // Note: At least in EA, Double Up can also double the Path of Stars reward!
-const doubleUp: Boon = {
+export const doubleUp: Boon = {
   name: "Double Up",
   type: OTHER,
   info: (value) =>
     `Whenever you claim a Minor Find or similar resource reward, a copy has a ${value} chance to appear`,
   values: {
-    [COMMON]: { 1: "20%", },
-    [RARE]: { 1: "25%", },
-    [EPIC]: { 1: "30%", },
+    [COMMON]: { 1: "20%" },
+    [RARE]: { 1: "25%" },
+    [EPIC]: { 1: "30%" },
   },
 };
 
-const fluidGain: Boon = {
+export const fluidGain: Boon = {
   name: "Fluid Gain",
   type: OTHER,
+  element: WATER,
   info: (value) =>
     `After you strike foes with your Weapon, a Spirit Bubble has a ${value} chance to appear`,
   values: {
@@ -104,6 +147,7 @@ const fluidGain: Boon = {
     },
   },
 };
+
 const hydraulicMight: Boon = {
   name: "Hydraulic Might",
   type: OTHER,
@@ -117,7 +161,7 @@ const hydraulicMight: Boon = {
 
 const waterFitness: Boon = {
   name: "Water Fitness",
-  type: OTHER,
+  type: INFUSION,
   info: (value) =>
     `If you have at least 4 [water] boons, then gain ${value} max health`,
   values: {
@@ -125,35 +169,41 @@ const waterFitness: Boon = {
   },
 };
 
-const sunkenTreasure: Boon = {
+export const sunkenTreasure: Boon = {
   name: "Sunken Treasure",
   type: OTHER,
   element: WATER,
   info: (value) =>
     `Gain ${value} [gold], [max health], and sometimes [ashes] and [psyche].`,
   values: {
+    [COMMON]: { 1: 90 },
     [RARE]: { 1: 117 },
   },
-}
+};
 
-const oceansBounty: Boon = {
+export const oceansBounty: Boon = {
   name: "Ocean's Bounty",
   type: OTHER,
+  element: WATER,
   info: (value) =>
     `Any Minor Finds and [coins] you find are worth ${value} more`,
   values: {
+    [COMMON]: { 1: "50%" },
     [RARE]: { 1: "75%" },
   },
 };
 
-const slipperySlope: Boon = {
+export const slipperySlope: Boon = {
   name: "Slippery Slope",
   type: OTHER,
+  element: WATER,
   info: (value) =>
     `Your splash effects from Poseidon also inflict Slip on foes for ${value} bonus damage`,
   values: {
+    [COMMON]: { 1: "5%" },
     [RARE]: { 1: "10%" },
   },
+  prerequisites: [[waveStrike, waveFlourish]],
 };
 
 const crashingWave: Boon = {
@@ -163,20 +213,23 @@ const crashingWave: Boon = {
   info: (value) =>
     `Whenever your knock-away effects slam foes into barriers, create a blast in the area that deals ${value} damage`,
   values: {
-    [COMMON]: { 1: 50, },
-    [RARE]: { 1: 72, },
-    [EPIC]: { 1: 94, },
+    [COMMON]: { 1: 50 },
+    [RARE]: { 1: 72 },
+    [EPIC]: { 1: 94 },
   },
+  prerequisites: [[waveStrike, waveFlourish, geyserRing, breakerSprint]],
 };
 
 const kingTide: Boon = {
   name: "King Tide",
   type: OTHER,
+  element: WATER,
   info: (value) =>
     `Your splash effects from Poseidon are larger and deal ${value} bonus damage to Guardians`,
   values: {
     [LEGENDARY]: { 1: "150%" },
   },
+  prerequisites: [[waveStrike, waveFlourish], [slipperySlope], [crashingWave]],
 };
 
 const islandGetaway: Boon = {
@@ -187,6 +240,111 @@ const islandGetaway: Boon = {
   values: {
     [DUO]: { 1: "15%" },
   },
+  prerequisites: [
+    [waveStrike, waveFlourish, geyserRing, breakerSprint],
+    [flutterStrike, flutterFlourish],
+  ],
+};
+
+const naturalSelection: Boon = {
+  name: "Natural Selection",
+  type: OTHER,
+  info: (value) =>
+    `Location Rewards exclude max health, max [mana], and gold. Boon are ${value} more likely to be Rare or better`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [fluidGain, breakerSprint, oceansBounty, sunkenTreasure, doubleUp],
+    [tranquilGain, frigidSprint, winterCoat, coldStorage, rareCrop],
+  ],
+};
+
+const killerCurrent: Boon = {
+  name: "Killer Current",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your lightning deals ${value} bonus damage to [slip]-afflicted foes`,
+  values: {
+    [DUO]: { 1: "30%" },
+  },
+  prerequisites: [
+    [slipperySlope],
+    [
+      heavenStrike,
+      heavenFlourish,
+      stormRing,
+      thunderSprint,
+      divineVengeance,
+      lightningLance,
+    ],
+  ],
+};
+
+const seismicHammer: Boon = {
+  name: "Seismic Hammer",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your [omega] cast occasionally creates a blast that deals 500 damage in the area. Recharges after ${value} seconds`,
+  values: {
+    [DUO]: { 1: 15 },
+  },
+  prerequisites: [
+    [geyserRing],
+    [volcanicStrike, volcanicFlourish, smithySprint],
+  ],
+};
+
+const goldenRule: Boon = {
+  name: "Golden Rule",
+  type: OTHER,
+  info: (value) => `You deal ${value} more damage per 100 gold you have`,
+  values: {
+    [DUO]: "5%",
+  },
+  prerequisites: [
+    [swornStrike, nexusSprint, bornGain],
+    [geyserRing, breakerSprint, fluidGain],
+    [oceansBounty, doubleUp],
+  ],
+};
+
+const beachBall: Boon = {
+  name: "Beach Ball",
+  type: OTHER,
+  info: (value) =>
+    `Your Sprint creates a water sphere behind you. After you stop, it surges ahead and bursts for ${value} damage`,
+  values: {
+    [DUO]: { 1: 140 },
+  },
+  prerequisites: [
+    [blindingSprint, lucidGain],
+    [breakerSprint, fluidGain],
+  ],
+};
+
+const scaldingVapor: Boon = {
+  name: "Scalding Vapor",
+  type: OTHER,
+  info: (value) =>
+    `If foes with [slip] are struck with fire from Hestia, they are engulfed in [steam] that deals ${value} damage every 0.2 seconds`,
+  values: {
+    [DUO]: { 1: 25 },
+  },
+  prerequisites: [
+    [slipperySlope],
+    [
+      flameStrike,
+      flameFlourish,
+      smolderRing,
+      spontaneousCombustion,
+      burningDesire,
+      controlledBurn,
+      glowingCoal,
+    ],
+  ],
 };
 
 const abilities = {
@@ -205,6 +363,12 @@ const abilities = {
   crashingWave,
   kingTide,
   islandGetaway,
+  naturalSelection,
+  killerCurrent,
+  seismicHammer,
+  goldenRule,
+  beachBall,
+  scaldingVapor,
 };
 
 const base: God = {

--- a/src/data/gods/zeus.ts
+++ b/src/data/gods/zeus.ts
@@ -1,9 +1,41 @@
-import { COMMON, RARE, EPIC, LEGENDARY, HEROIC, DUO } from "./rarities";
-import { abilityFormatter } from "./formatters";
-import { ATTACK, SPECIAL, CAST, DASH, OTHER, GAIN } from "./abilityTypes";
 import { mapValues, toArray } from "lodash";
+import {
+  ATTACK,
+  CAST,
+  DASH,
+  GAIN,
+  INFUSION,
+  OTHER,
+  SPECIAL,
+} from "./abilityTypes";
+import {
+  flutterFlourish,
+  flutterStrike,
+  passionDash,
+  raptureRing,
+} from "./aphrodite";
+import { solarRing } from "./apollo";
+import { arcticRing, frigidSprint, iceFlourish, iceStrike } from "./demeter";
+import { AIR, COSMIC } from "./elements";
+import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
-import { AIR } from "./elements";
+import {
+  fixedGain,
+  heavyMetal,
+  mintCondition,
+  toughTrade,
+  trustyShield,
+} from "./hephaestus";
+import {
+  bornGain,
+  engagementRing,
+  nexusSprint,
+  swornFlourish,
+  swornStrike,
+} from "./hera";
+import { flameFlourish, flameStrike } from "./hestia";
+import { slipperySlope } from "./poseidon";
+import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
 
 const info =
   "Zeus, God of Thunder. His powers create bouncing lightning projectiles.";
@@ -26,6 +58,8 @@ const attack: Boon = {
   },
 };
 
+export const heavenStrike: Boon = attack;
+
 const special: Boon = {
   name: "Heaven Flourish",
   type: SPECIAL,
@@ -41,6 +75,8 @@ const special: Boon = {
   },
 };
 
+export const heavenFlourish: Boon = special;
+
 const cast: Boon = {
   name: "Storm Ring",
   type: CAST,
@@ -54,6 +90,8 @@ const cast: Boon = {
   },
 };
 
+export const stormRing: Boon = cast;
+
 const dash: Boon = {
   name: "Thunder Sprint",
   type: DASH,
@@ -65,6 +103,8 @@ const dash: Boon = {
     [RARE]: { 1: 25 },
   },
 };
+
+export const thunderSprint: Boon = dash;
 
 const gain: Boon = {
   name: "Ionic Gain",
@@ -78,31 +118,32 @@ const gain: Boon = {
   },
 };
 
+export const ionicGain: Boon = gain;
+
 // Infusion
 const airQuality: Boon = {
   name: "Air Quality",
-  type: OTHER,
+  type: INFUSION,
   info: (value) =>
     `While you have at least 5 [air], you can never deal less damage than ${value} per hit.`,
   values: {
-    [COMMON]: { 1: 30, },
-    [RARE]: { 1: 30, },
+    [COMMON]: { 1: 30 },
   },
 };
 
-const divineVengeance: Boon = {
+export const divineVengeance: Boon = {
   name: "Divine Vengeance",
   type: OTHER,
   element: AIR,
   info: (value) =>
     `After you take damage, your foe is struck by lightning for 100 damage, and again 50% of the time (up to ${value} times)`,
   values: {
-    [COMMON]: { 1: 2, },
-    [RARE]: { 1: 3, },
+    [COMMON]: { 1: 2 },
+    [RARE]: { 1: 3 },
   },
 };
 
-const lightningLance: Boon = {
+export const lightningLance: Boon = {
   name: "Lightning Lance",
   type: OTHER,
   element: AIR,
@@ -119,78 +160,198 @@ const lightningLance: Boon = {
   },
 };
 
-const staticShock: Boon = {
+export const staticShock: Boon = {
   name: "Static Shock",
   type: OTHER,
   element: AIR,
   info: (value) =>
     `After you enter a Location, [prime] 50 [mana] to make your strikes emit chain-lightning that deals ${value} damage`,
   values: {
-    [COMMON]: { 1: 10, },
-    [RARE]: { 1: 15, },
-    [EPIC]: { 1: 20, },
-  },
-};
-
-const doubleStrike: Boon = {
-  name: "Double Strike",
-  type: OTHER,
-  info: (value) =>
-    `Your lightning bolt effects have a ${value} chance to strike 1 more time`,
-  values: {
-    [COMMON]: { 1: "5%", 2: "10%" },
-    [EPIC]: { 1: "15%", 4: "25%" },
+    [COMMON]: { 1: 10 },
+    [RARE]: { 1: 15 },
+    [EPIC]: { 1: 20 },
   },
 };
 
 const spiritSurge: Boon = {
   name: "Spirit Surge",
   type: OTHER,
+  element: AIR,
   info: (value) =>
     `While you have no more than 10 [mana], all foes are occasionally struck by lightning for ${value} damage`,
   values: {
+    [COMMON]: { 1: 60 },
     [EPIC]: { 1: "90" },
   },
+};
+
+const doubleStrike: Boon = {
+  name: "Double Strike",
+  type: OTHER,
+  element: AIR,
+  info: (value) =>
+    `Your lightning bolt effects have a ${value} chance to strike 1 more time`,
+  values: {
+    [COMMON]: { 1: "5%", 2: "10%" },
+    [EPIC]: { 1: "15%", 4: "25%" },
+  },
+  prerequisites: [
+    [
+      heavenStrike,
+      heavenFlourish,
+      stormRing,
+      thunderSprint,
+      spiritSurge,
+      divineVengeance,
+      lightningLance,
+    ],
+  ],
 };
 
 const kingsRansom: Boon = {
   name: "King's Ransom",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `Give up all your Boons of Hera. For each raise all of your Boons of Zeus by ${value} levels`,
   values: {
     [DUO]: { 1: 2 },
   },
+  prerequisites: [
+    [swornFlourish, swornStrike, engagementRing, nexusSprint, bornGain],
+    [heavenFlourish, heavenStrike, stormRing, thunderSprint, ionicGain],
+  ],
 };
 
 const electricOverload: Boon = {
   name: "Electric Overload",
   type: OTHER,
+  element: AIR,
   info: (value) =>
     `Whenever your [blitz] effects activate, a bolt of chain-lightning fires from the foe dealing ${value} damage`,
   values: {
+    [COMMON]: { 1: 10 },
     [RARE]: { 1: 15 },
   },
+  prerequisites: [[heavenFlourish, heavenStrike]],
 };
 
 const masterConductor: Boon = {
   name: "Master Conductor",
   type: OTHER,
+  element: COSMIC,
   info: (value) =>
     `Your chain-lightning deals ${value} more damage per bounce and can bounce to you`,
   values: {
     [DUO]: { 1: "15%" },
   },
+  prerequisites: [
+    [staticShock],
+    [fixedGain, trustyShield, heavyMetal, mintCondition, toughTrade],
+  ],
 };
 
 const toastingFork: Boon = {
   name: "Toasting Fork",
   type: OTHER,
+  element: AIR,
   info: (value) =>
     `Your [blitz] effects deal ${value} damage even if they expire without being activated.`,
   values: {
+    [COMMON]: { 1: "75%" },
     [RARE]: { 1: "100%" },
   },
+  prerequisites: [[heavenFlourish, heavenStrike]],
+};
+
+const shockingLoss: Boon = {
+  name: "Shocking Loss",
+  type: OTHER,
+  element: AIR,
+  info: (value) =>
+    `Most foes have a ${value} chance to be instantly destroyed as soon as they enter the Encounter`,
+  values: {
+    [LEGENDARY]: { 1: "7%" },
+  },
+};
+
+const gloriousDisaster: Boon = {
+  name: "Glorious Disaster",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `You can Channel +30 [mana] into your [omega] Cast to repeatedly strike foes for ${value} bolt damage every 0.13 seconds`,
+  values: {
+    [LEGENDARY]: { 1: 50 },
+  },
+  prerequisites: [[solarRing], [heavenStrike, heavenFlourish, thunderSprint]],
+};
+
+const apocalypticStorm: Boon = {
+  name: "Apocalyptic Storm",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your [blitz] effects last ${value} seconds longer, and active against all [blitz]-afflicted foes at once`,
+  values: {
+    [DUO]: { 1: 8 },
+  },
+  prerequisites: [
+    [iceStrike, iceFlourish, arcticRing, frigidSprint],
+    [heavenStrike, heavenFlourish],
+  ],
+};
+
+const thermalDynamics: Boon = {
+  name: "Thermal Dynamics",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your [blitz] effects also inflict ${value} [scorch] whenever they deal damage`,
+  values: {
+    [DUO]: { 1: 80 },
+  },
+  prerequisites: [
+    [heavenStrike, heavenFlourish],
+    [flameFlourish, flameStrike],
+  ],
+};
+
+const killerCurrent: Boon = {
+  name: "Killer Current",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `Your lightning deals ${value} bonus damage to [slip]-afflicted foes`,
+  values: {
+    [DUO]: { 1: "30%" },
+  },
+  prerequisites: [
+    [slipperySlope],
+    [
+      heavenStrike,
+      heavenFlourish,
+      stormRing,
+      thunderSprint,
+      divineVengeance,
+      lightningLance,
+    ],
+  ],
+};
+
+const romanticSpark: Boon = {
+  name: "Romantic Spark",
+  type: OTHER,
+  element: COSMIC,
+  info: (value) =>
+    `If you Sprint into [blitz]-afflicted foes, the effect actives immediately and is ${value} stronger`,
+  values: {
+    [DUO]: { 1: "200%" },
+  },
+  prerequisites: [
+    [heavenFlourish, heavenStrike],
+    [passionDash, raptureRing, flutterFlourish, flutterStrike],
+  ],
 };
 
 const abilities = {


### PR DESCRIPTION
@sneakyteak This is everything from the in-game codex. Includes infusions, legendaries, duos, and all of the pre-requisites. Currently it isn't doing anything with infusion or pre-req information, but the content should be there for us to build commands around now

Does not include: chaos or biome npcs