### PR TITLE
Implements infusion command

### DIFF
--- a/features/infusions.feature
+++ b/features/infusions.feature
@@ -1,0 +1,15 @@
+Feature: Users can request information about infusions
+    Background:
+        Given a user {user1}
+        And a channel {sneakyteak}
+
+    Scenario: Users can request information about infusions
+        When the user says to the bot {!infusions}
+        Then the bot responds with {Infusions are a special type of boon}
+        And the bot responds with {[Earth] [Water] [Air] [Fire] [Cosmic]}
+
+    Scenario: Users can request available infusions for an element
+        When the user says to the bot {!infusions air}
+        Then the bot responds with {Infusions that require at least one [Air]}
+        And the bot responds with {Wispy Wiles (Aphrodite)}
+        And the bot responds with {Tall Order (Hermes)}

--- a/src/commands/all.ts
+++ b/src/commands/all.ts
@@ -11,6 +11,7 @@ import { elementCommand } from "./element";
 import { elementListCommand } from "./elementList";
 import { hexCommand } from "./hex";
 import { hexListCommand } from "./hexList";
+import { infusionCommand } from "./infusion";
 
 const allCommands = [
   pingCommand,
@@ -26,5 +27,6 @@ const allCommands = [
   elementListCommand,
   hexCommand,
   hexListCommand,
+  infusionCommand,
 ];
 export { allCommands };

--- a/src/commands/infusion.ts
+++ b/src/commands/infusion.ts
@@ -1,0 +1,105 @@
+import { find } from "lodash";
+import { gods } from "../data/gods/all";
+import { AIR, BoonElement, COSMIC, EARTH, FIRE, WATER } from "../data/gods/elements";
+import { InfusionBoon, isInfusion } from "../data/gods/god";
+import { Command } from "./command";
+
+const allElements = [EARTH, WATER, AIR, FIRE, COSMIC];
+const allElementNames = allElements.join("|");
+const infusionCommandExpression = RegExp(`^(infusions?) ?(${allElementNames})?$`, "i");
+
+type InfusionRecord = {
+  boon: string;
+  god: string;
+};
+const elementInfusionMap = gods.reduce<Record<BoonElement, InfusionRecord[]>>(
+  (hash, god) => {
+    // Assumes each god has no more than one infusion, which is currently true.
+    let infusionBoon = find(god.abilities, (boon, _) =>
+      isInfusion(boon)
+    ) as InfusionBoon;
+    if (!infusionBoon || !infusionBoon.requiredElements) {
+      return hash;
+    }
+
+    let record: InfusionRecord = { boon: infusionBoon.name, god: god.name };
+    return {
+      [EARTH]: infusionBoon.requiredElements.find((element) => element === EARTH)
+        ? [...hash[EARTH], record]
+        : hash[EARTH],
+      [WATER]: infusionBoon.requiredElements.find((element) => element === WATER)
+        ? [...hash[WATER], record]
+        : hash[WATER],
+      [AIR]: infusionBoon.requiredElements.find((element) => element === AIR)
+        ? [...hash[AIR], record]
+        : hash[AIR],
+      [FIRE]: infusionBoon.requiredElements.find((element) => element === FIRE)
+        ? [...hash[FIRE], record]
+        : hash[FIRE],
+      [COSMIC]: infusionBoon.requiredElements.find((element) => element === COSMIC)
+        ? [...hash[COSMIC], record]
+        : hash[COSMIC],
+    }
+  },
+  {
+    [EARTH]: [],
+    [WATER]: [],
+    [AIR]: [],
+    [FIRE]: [],
+    [COSMIC]: [],
+  }
+);
+
+const infusionCommand = new Command({
+  command: infusionCommandExpression,
+  name: "Infusions",
+  test: false,
+  example: "infusions water",
+  handler: async ({ bot, channelId, commandMatches, logger }) => {
+    logger.debug("Command matches: " + JSON.stringify(commandMatches));
+    const channel = channelId.slice(1);
+    logger.debug("My channel is " + channel);
+    const elementFromUser = commandMatches[2];
+    
+    const formattedElementNames = allElements.map((name) => `[${name}]`).join(" ");
+    const defaultMessage =
+      "Infusions are a special type of boon that rewards stockpiling " +
+      "elemental boons. Available elements: " + formattedElementNames;
+
+    if (!elementFromUser) {
+      logger.debug("No element provided. Defaulting to infusions overview.");
+      return bot.say(channel, defaultMessage);
+    }
+
+    const matchedElement = allElements.find((element) =>
+      element.match(RegExp(elementFromUser, "i"))
+    );
+
+    if (!matchedElement) {
+      logger.debug("No element matched. Defaulting to infusions overview.");
+      return bot.say(channel, defaultMessage);
+    }
+
+    // Protects us if an element doesn't yet exist in the actual data.
+    const infusions = elementInfusionMap[matchedElement as keyof typeof elementInfusionMap];
+    if (!infusions) {
+      logger.debug(
+        "Matched infusionCommand with: " +
+          elementFromUser +
+          " but no infusions in the data have this element."
+      );
+      return;
+    }
+
+    const formattedBoons = infusions
+      .map((record) => `[${record.boon} (${record.god})]`)
+      .join(" ");
+
+    const message =
+      `Infusions that require at least one [${matchedElement}]: ${formattedBoons}`
+    
+    return bot.say(channel, message);
+  },
+});
+
+export { infusionCommand };

--- a/src/commands/infusion.ts
+++ b/src/commands/infusion.ts
@@ -15,31 +15,20 @@ type InfusionRecord = {
 const elementInfusionMap = gods.reduce<Record<BoonElement, InfusionRecord[]>>(
   (hash, god) => {
     // Assumes each god has no more than one infusion, which is currently true.
-    let infusionBoon = find(god.abilities, (boon, _) =>
-      isInfusion(boon)
-    ) as InfusionBoon;
-    if (!infusionBoon || !infusionBoon.requiredElements) {
+    const infusionBoon = Object.values(god.abilities).find(isInfusion);
+    if (!infusionBoon) {
       return hash;
     }
 
-    let record: InfusionRecord = { boon: infusionBoon.name, god: god.name };
-    return {
-      [EARTH]: infusionBoon.requiredElements.find((element) => element === EARTH)
-        ? [...hash[EARTH], record]
-        : hash[EARTH],
-      [WATER]: infusionBoon.requiredElements.find((element) => element === WATER)
-        ? [...hash[WATER], record]
-        : hash[WATER],
-      [AIR]: infusionBoon.requiredElements.find((element) => element === AIR)
-        ? [...hash[AIR], record]
-        : hash[AIR],
-      [FIRE]: infusionBoon.requiredElements.find((element) => element === FIRE)
-        ? [...hash[FIRE], record]
-        : hash[FIRE],
-      [COSMIC]: infusionBoon.requiredElements.find((element) => element === COSMIC)
-        ? [...hash[COSMIC], record]
-        : hash[COSMIC],
-    }
+    const record: InfusionRecord = { boon: infusionBoon.name, god: god.name };
+    const requiredElements = infusionBoon.requiredElements;
+    const result = requiredElements.reduce((resultHash, requiredElement) => {
+      return {
+        ...resultHash,
+        [requiredElement]: [...hash[requiredElement], record]
+      }
+    }, {...hash});
+    return result;
   },
   {
     [EARTH]: [],

--- a/src/data/gods/abilityTypes.ts
+++ b/src/data/gods/abilityTypes.ts
@@ -1,11 +1,12 @@
-export type BoonType =
+export type StandardBoonType =
   | typeof ATTACK
   | typeof SPECIAL
   | typeof CAST
   | typeof DASH
   | typeof GAIN
-  | typeof OTHER
-  | typeof INFUSION;
+  | typeof OTHER;
+
+export type InfusionBoonType = typeof INFUSION;
 
 const ATTACK = "Attack";
 const SPECIAL = "Special";

--- a/src/data/gods/aphrodite.ts
+++ b/src/data/gods/aphrodite.ts
@@ -13,7 +13,7 @@ import { lucidGain, novaFlourish, novaStrike, solarRing } from "./apollo";
 import { plentifulForage, winterCoat } from "./demeter";
 import { AIR, COSMIC, WATER } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import { anvilRing, fixedGain, smithySprint } from "./hephaestus";
 import { nastyComeback, nexusSprint, swornFlourish, swornStrike } from "./hera";
 import { hearthGain, smolderRing, sootSprint } from "./hestia";
@@ -112,7 +112,7 @@ const gain: Boon = {
 
 export const glamourGain = gain;
 
-const wispyWiles: Boon = {
+const wispyWiles: InfusionBoon = {
   name: "Wispy Wiles",
   type: INFUSION,
   info: (value) =>
@@ -120,6 +120,7 @@ const wispyWiles: Boon = {
   values: {
     [COMMON]: { 1: "15%" },
   },
+  requiredElements: [AIR],
 };
 
 export const shamelessAttitude: Boon = {

--- a/src/data/gods/apollo.ts
+++ b/src/data/gods/apollo.ts
@@ -12,7 +12,7 @@ import { heartBreaker } from "./aphrodite";
 import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
 import { AIR, COSMIC, FIRE } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, nexusSprint } from "./hera";
 import {
@@ -157,7 +157,7 @@ const lightSmite: Boon = {
   },
 };
 
-const selfHealing: Boon = {
+const selfHealing: InfusionBoon = {
   name: `Self Healing`,
   type: INFUSION,
   info: (value) =>
@@ -165,6 +165,7 @@ const selfHealing: Boon = {
   values: {
     [COMMON]: { 1: "30%" },
   },
+  requiredElements: [FIRE],
 };
 
 const perfectImage: Boon = {

--- a/src/data/gods/demeter.ts
+++ b/src/data/gods/demeter.ts
@@ -8,7 +8,7 @@ import {
 import { blindingSprint, lucidGain, solarRing } from "./apollo";
 import { COSMIC, EARTH, WATER } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, nexusSprint } from "./hera";
 import { flameFlourish, flameStrike } from "./hestia";
@@ -173,7 +173,7 @@ export const plentifulForage: Boon = {
   },
 };
 
-const coarseGrit: Boon = {
+const coarseGrit: InfusionBoon = {
   name: `Coarse Grit`,
   type: INFUSION,
   info: (value) =>
@@ -183,6 +183,7 @@ const coarseGrit: Boon = {
       1: 15,
     },
   },
+  requiredElements: [EARTH],
 };
 
 export const winterCoat: Boon = {

--- a/src/data/gods/god.ts
+++ b/src/data/gods/god.ts
@@ -1,4 +1,4 @@
-import { BoonType } from "./abilityTypes";
+import { StandardBoonType, InfusionBoonType, INFUSION } from "./abilityTypes";
 import { BoonElement } from "./elements";
 import { BoonRarity } from "./rarities";
 
@@ -6,13 +6,23 @@ export type BoonValues = Partial<
   Record<BoonRarity, { [level: number]: string | number }>
 >;
 
-export type Boon = {
+export type Boon = StandardBoon | InfusionBoon;
+
+type StandardBoon = {
   name: string;
-  type: BoonType;
+  type: StandardBoonType;
   element?: BoonElement;
   info: (value: string) => string;
   values: BoonValues;
   prerequisites?: Array<Array<Boon>>;
+};
+
+export const isInfusion =
+  (boon: Boon): boon is InfusionBoon => boon.type === INFUSION
+
+export type InfusionBoon = Omit<StandardBoon, "type" | "requiredElements"> & {
+  type: InfusionBoonType;
+  requiredElements: Array<BoonElement>;
 };
 
 export type God = {

--- a/src/data/gods/god.ts
+++ b/src/data/gods/god.ts
@@ -20,7 +20,7 @@ type StandardBoon = {
 export const isInfusion =
   (boon: Boon): boon is InfusionBoon => boon.type === INFUSION
 
-export type InfusionBoon = Omit<StandardBoon, "type" | "requiredElements"> & {
+export type InfusionBoon = Omit<StandardBoon, "type" | "element?" | "prerequisites?"> & {
   type: InfusionBoonType;
   requiredElements: Array<BoonElement>;
 };

--- a/src/data/gods/hephaestus.ts
+++ b/src/data/gods/hephaestus.ts
@@ -5,7 +5,7 @@ import { novaFlourish, novaStrike, superNova } from "./apollo";
 import { iceFlourish, iceStrike } from "./demeter";
 import { COSMIC, EARTH, FIRE } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import { bornGain, braveFace, keenIntuition, nastyComeback } from "./hera";
 import { flameFlourish, flameStrike, smolderRing } from "./hestia";
 import { geyserRing } from "./poseidon";
@@ -83,14 +83,16 @@ const dash: Boon = {
 
 export const smithySprint: Boon = dash;
 
-const martialArt: Boon = {
+const martialArt: InfusionBoon = {
   name: "Martial Art",
   type: INFUSION,
+  // TODO(sneakyteak): Verify this infusion. Did it change from +5% damage per Earth?
   info: (value) =>
     `After you hit with an Attack or Special, your next Attack or Special deals ${value} more damage`,
   values: {
     [RARE]: { 1: "50%" },
   },
+  requiredElements: [EARTH],
 };
 
 export const toughTrade: Boon = {

--- a/src/data/gods/hera.ts
+++ b/src/data/gods/hera.ts
@@ -5,7 +5,7 @@ import { blindingSprint, lucidGain, solarRing } from "./apollo";
 import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
 import { COSMIC, EARTH } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import {
   fixedGain,
   heavyMetal,
@@ -105,7 +105,7 @@ const cast: Boon = {
 
 export const engagementRing = cast;
 
-const properUpbringing: Boon = {
+const properUpbringing: InfusionBoon = {
   name: "Proper Upbringing",
   type: INFUSION,
   info: (value) =>
@@ -113,6 +113,7 @@ const properUpbringing: Boon = {
   values: {
     [COMMON]: { 1: "RARE" },
   },
+  requiredElements: [EARTH],
 };
 
 export const keenIntuition: Boon = {

--- a/src/data/gods/hermes.ts
+++ b/src/data/gods/hermes.ts
@@ -1,8 +1,8 @@
 import { mapValues, toArray } from "lodash";
 import { INFUSION, OTHER } from "./abilityTypes";
-import { AIR, EARTH, FIRE } from "./elements";
+import { AIR, EARTH, FIRE, WATER } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import { COMMON, EPIC, LEGENDARY, RARE } from "./rarities";
 
 const info =
@@ -123,7 +123,7 @@ const savedBreath: Boon = {
   },
 };
 
-const tallOrder: Boon = {
+const tallOrder: InfusionBoon = {
   name: "Tall Order",
   type: INFUSION,
   info: (value) =>
@@ -131,6 +131,7 @@ const tallOrder: Boon = {
   values: {
     [COMMON]: { 1: "20%" },
   },
+  requiredElements: [EARTH, WATER, AIR, FIRE],
 };
 
 const midnightOil: Boon = {

--- a/src/data/gods/hestia.ts
+++ b/src/data/gods/hestia.ts
@@ -5,7 +5,7 @@ import { lucidGain, novaFlourish, novaStrike } from "./apollo";
 import { iceFlourish, iceStrike } from "./demeter";
 import { COSMIC, FIRE } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import { volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, swornFlourish, swornStrike } from "./hera";
 import { slipperySlope } from "./poseidon";
@@ -119,7 +119,7 @@ export const burntOffering: Boon = {
     },
   },
 };
-const slowCooker: Boon = {
+const slowCooker: InfusionBoon = {
   name: "Slow Cooker",
   type: INFUSION,
   info: (value) =>
@@ -129,6 +129,7 @@ const slowCooker: Boon = {
       1: 2,
     },
   },
+  requiredElements: [FIRE],
 };
 
 export const glowingCoal: Boon = {

--- a/src/data/gods/poseidon.ts
+++ b/src/data/gods/poseidon.ts
@@ -11,7 +11,7 @@ import {
 } from "./demeter";
 import { COSMIC, WATER } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, nexusSprint, swornStrike } from "./hera";
 import {
@@ -159,7 +159,7 @@ const hydraulicMight: Boon = {
   },
 };
 
-const waterFitness: Boon = {
+const waterFitness: InfusionBoon = {
   name: "Water Fitness",
   type: INFUSION,
   info: (value) =>
@@ -167,6 +167,7 @@ const waterFitness: Boon = {
   values: {
     [COMMON]: { 1: 100 },
   },
+  requiredElements: [WATER],
 };
 
 export const sunkenTreasure: Boon = {

--- a/src/data/gods/zeus.ts
+++ b/src/data/gods/zeus.ts
@@ -18,7 +18,7 @@ import { solarRing } from "./apollo";
 import { arcticRing, frigidSprint, iceFlourish, iceStrike } from "./demeter";
 import { AIR, COSMIC } from "./elements";
 import { abilityFormatter } from "./formatters";
-import { Boon, God } from "./god";
+import { Boon, God, InfusionBoon } from "./god";
 import {
   fixedGain,
   heavyMetal,
@@ -120,8 +120,7 @@ const gain: Boon = {
 
 export const ionicGain: Boon = gain;
 
-// Infusion
-const airQuality: Boon = {
+const airQuality: InfusionBoon = {
   name: "Air Quality",
   type: INFUSION,
   info: (value) =>
@@ -129,6 +128,7 @@ const airQuality: Boon = {
   values: {
     [COMMON]: { 1: 30 },
   },
+  requiredElements: [AIR],
 };
 
 export const divineVengeance: Boon = {


### PR DESCRIPTION
Adds new infusion command, which supports both default !infusions and specific !infusions [element] syntax. Tests this feature in a series of new scenarios. Supports this by splitting the Boon type into StandardBoon and InfusionBoon. Involves a minor refactor of most gods.