### PR TITLE
Implements prereq command

### DIFF
--- a/features/boons.feature
+++ b/features/boons.feature
@@ -9,14 +9,24 @@ Feature: A user can request information about a specific boon
 
     Scenario: A user requests info about a boon with no prereqs
         When the user says to the bot {!flutter strike}
-        Then the bot does not respond with {has prereq}
+        Then the bot does not respond with {has requirements}
 
     Scenario: A user requests info about a boon with prereqs
         When the user says to the bot {!ecstatic obsession}
-        Then the bot responds with {has prereq}
+        Then the bot responds with {has requirements}
 
     Scenario: A user asks about a boons prereqs
-        When the user says to the bot {!ecstatic obsession prereqs}
-        Then the bot responds with {Prerequisites for Ecstatic Obsession (Aphrodite)}
+        When the user says to the bot {!ecstatic obsession reqs}
+        Then the bot responds with {Requirements for Ecstatic Obsession (Aphrodite)}
+        And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
+        And the bot responds with {and (one of [Rapture Ring][Passion Dash][Glamour Gain])}
+
+    Scenario: A user asks for prereqs for a boon that has none
+        When the user says to the bot {!flutter strike reqs}
+        Then the bot responds with {No known requirements}
+
+    Scenario: A user asks for prereqs with alternate syntax
+        When the user says to the bot {!ecstatic obsession requirements}
+        Then the bot responds with {Requirements for Ecstatic Obsession (Aphrodite)}
         And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
         And the bot responds with {and (one of [Rapture Ring][Passion Dash][Glamour Gain])}

--- a/features/boons.feature
+++ b/features/boons.feature
@@ -6,3 +6,17 @@ Feature: A user can request information about a specific boon
     Scenario: A user can request information about a specific boon
         When the user says to the bot {!air quality}
         Then the bot responds with {Air Quality (Zeus) - While you have at least 5 [air], you can never deal less damage than (c:30) per hit}
+
+    Scenario: A user requests info about a boon with no prereqs
+        When the user says to the bot {!flutter strike}
+        Then the bot does not respond with {has prereq}
+
+    Scenario: A user requests info about a boon with prereqs
+        When the user says to the bot {!ecstatic obsession}
+        Then the bot responds with {has prereq}
+
+    Scenario: A user asks about a boons prereqs
+        When the user says to the bot {!ecstatic obsession prereqs}
+        Then the bot responds with {Prerequisites for Ecstatic Obsession (Aphrodite)}
+        And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
+        And the bot responds with {and (one of [Rapture Ring][Passion Dash][Glamour Gain])}

--- a/features/support/bot_steps.ts
+++ b/features/support/bot_steps.ts
@@ -77,7 +77,7 @@ Then(
   /the bot does not respond with {(.*)}/,
   function (this: CustomWorld, expectedMessage: string) {
     const { bot } = this.mocks;
-    const calledWith = bot.say.lastArg;
+    const calledWith = bot.say.getCall(0).args;
     const actualResponseChannel = sanitizeChannel(calledWith[0]);
     const expectedResponseChannel = sanitizeChannel(this.given.channelId);
     const actualResponseMessage = calledWith[1];

--- a/src/commands/boon.ts
+++ b/src/commands/boon.ts
@@ -39,7 +39,7 @@ const abilityExpressionMap = mapKeys(abilityMapWithoutNone, (_, abilityName) =>
 
 const abilityNameRegexes = Object.keys(abilityExpressionMap).join("|");
 
-const abilityCommand = RegExp(`^(${abilityNameRegexes}) ?((?:pre)?reqs)?$`, "i");
+const abilityCommand = RegExp(`^(${abilityNameRegexes})( req(?:uirement)?s)?$`, "i");
 
 const boonCommand = new Command({
   command: abilityCommand,
@@ -67,7 +67,7 @@ const boonCommand = new Command({
 
       const prereqMessage = abilityPrereqMap[abilityKey]();
       if (!prereqMessage || prereqMessage === "") {
-        return bot.say(channelId, "No known prereqs.");
+        return bot.say(channelId, "No known requirements.");
       }
 
       return bot.say(channelId, prereqMessage);

--- a/src/data/gods/formatters.ts
+++ b/src/data/gods/formatters.ts
@@ -33,7 +33,7 @@ const abilityFormatter =
     const valueString = summaryFormatter(values);
     // Some boons, like infusions, have no element
     const formattedElement = element ? `[${element}] ` : "";
-    const hasPrereqs = prerequisites ? " [has prereqs]" : "";
+    const hasPrereqs = prerequisites ? " [has requirements]" : "";
     return `${name} (${god}) ${formattedElement}- ${info(valueString)}${hasPrereqs}`;
   };
 
@@ -56,7 +56,7 @@ const prereqsFormatter =
         }
       ).join(" and ");
 
-    return `Prerequisites for ${name} (${god}): ${prereqsString}`
+    return `Requirements for ${name} (${god}): ${prereqsString}`
   };
 
 export { summaryFormatter, abilityFormatter, prereqsFormatter };

--- a/src/data/gods/formatters.ts
+++ b/src/data/gods/formatters.ts
@@ -28,11 +28,35 @@ const summaryFormatter = (values: BoonValues) => {
 
 const abilityFormatter =
   (god: string) =>
-  ({ name, type, element, info, values }: Boon) =>
+  ({ name, type, element, info, values, prerequisites }: Boon) =>
   (rarity?: BoonRarity, level?: number) => {
     const valueString = summaryFormatter(values);
     // Some boons, like infusions, have no element
     const formattedElement = element ? `[${element}] ` : "";
-    return `${name} (${god}) ${formattedElement}- ${info(valueString)}`;
+    const hasPrereqs = prerequisites ? " [has prereqs]" : "";
+    return `${name} (${god}) ${formattedElement}- ${info(valueString)}${hasPrereqs}`;
   };
-export { summaryFormatter, abilityFormatter };
+
+const prereqsFormatter =
+  (god: string) =>
+  ({ name, prerequisites }: Boon) => {
+    if (!prerequisites) {
+      return "";
+    }
+
+    const prereqsString = prerequisites
+      .map(
+        (boonList) => {
+          let boonSet = boonList.reduce(
+            (currentBoons, boon) => {
+              return `${currentBoons}[${boon.name}]`
+            }, ""
+          );
+          return `(one of ${boonSet})`;
+        }
+      ).join(" and ");
+
+    return `Prerequisites for ${name} (${god}): ${prereqsString}`
+  };
+
+export { summaryFormatter, abilityFormatter, prereqsFormatter };


### PR DESCRIPTION
Adds an extension of the boon command which responds to command syntax like !flutter flourish prereqs. Code satisfies new scenarios which test prereqs queries. Adds a new formatter to construct prereq strings. As prereq definitions ask almost every god to depend on almost every other god, it seemed important in testing for the formatter to not be called until runtime / in the handler. Attempts to add the strings to god definitions choked on incomplete data in the prereq arrays.