### PR TITLE
Boon command and gods data refactor

### DIFF
--- a/features/boons.feature
+++ b/features/boons.feature
@@ -7,6 +7,10 @@ Feature: A user can request information about a specific boon
         When the user says to the bot {!air quality}
         Then the bot responds with {Air Quality (Zeus) - While you have at least 5 [air], you can never deal less damage than (c:30) per hit}
 
+    Scenario: A user can request information about a boon with alternate syntax
+        When the user says to the bot {!airQuality}
+        Then the bot responds with {Air Quality (Zeus) - While you have at least 5 [air], you can never deal less damage than (c:30) per hit}
+
     Scenario: A user requests info about a boon with no prereqs
         When the user says to the bot {!flutter strike}
         Then the bot does not respond with {has requirements}
@@ -15,7 +19,7 @@ Feature: A user can request information about a specific boon
         When the user says to the bot {!ecstatic obsession}
         Then the bot responds with {has requirements}
 
-    Scenario: A user asks about a boons prereqs
+    Scenario: A user asks about a boon's prereqs
         When the user says to the bot {!ecstatic obsession reqs}
         Then the bot responds with {Requirements for Ecstatic Obsession (Aphrodite)}
         And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
@@ -25,8 +29,14 @@ Feature: A user can request information about a specific boon
         When the user says to the bot {!flutter strike reqs}
         Then the bot responds with {No known requirements}
 
-    Scenario: A user asks for prereqs with alternate syntax
+    Scenario: A user asks for prereqs with alternate reqs syntax
         When the user says to the bot {!ecstatic obsession requirements}
+        Then the bot responds with {Requirements for Ecstatic Obsession (Aphrodite)}
+        And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
+        And the bot responds with {and (one of [Rapture Ring][Passion Dash][Glamour Gain])}
+
+    Scenario: A user asks for prereqs with alternate boon syntax
+        When the user says to the bot {!ecstaticObsession reqs}
         Then the bot responds with {Requirements for Ecstatic Obsession (Aphrodite)}
         And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
         And the bot responds with {and (one of [Rapture Ring][Passion Dash][Glamour Gain])}

--- a/features/boons.feature
+++ b/features/boons.feature
@@ -40,3 +40,8 @@ Feature: A user can request information about a specific boon
         Then the bot responds with {Requirements for Ecstatic Obsession (Aphrodite)}
         And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
         And the bot responds with {and (one of [Rapture Ring][Passion Dash][Glamour Gain])}
+
+    Scenario: A user asks for a duo that has the same name for two gods
+        Given PENDING
+        When the user says to the bot {!golden rule}
+        Then the bot responds with {this is broken; chooses one of the two gods}

--- a/features/gods.feature
+++ b/features/gods.feature
@@ -1,0 +1,49 @@
+Feature: Requests about gods and their boons
+    Background: Channel and user
+        Given a user {user1}
+        And a channel {sneakyteak}
+
+    Scenario: A user can request information about a god
+        When the user says to the bot {!poseidon}
+        Then the bot responds with {Poseidon, God of the Sea. His powers knock enemies away.}
+        And the bot responds with {[attack] [special] [cast] [dash] [other] [infusion] [duos]}
+
+    Scenario: A user can request information about a god's attack
+        When the user says to the bot {!poseidon attack}
+        Then the bot responds with {Wave Strike (Poseidon)}
+        And the bot responds with {Your Attacks hit foes with a splash that knocks foes away and deals}
+        And the bot responds with {c:15}
+
+    Scenario: A user can request information about a god's special
+        When the user says to the bot {!poseidon special}
+        Then the bot responds with {Wave Flourish (Poseidon) [Water]}
+        And the bot responds with {Your Specials hit foes with a splash that knocks other foes away and deals}
+        And the bot responds with {(c:20 r:30 e:40)}
+
+    Scenario: A user can request information about a god's cast
+        When the user says to the bot {!poseidon cast}
+        Then the bot responds with {Geyser Ring (Poseidon) [Water]}
+        And the bot responds with {Your [omega] Cast immediately detonates, dealing (c:100 r:150) damage and knocking foes away}
+
+    Scenario: A user can request information about a god's dash
+        When the user says to the bot {!poseidon dash}
+        Then the bot responds with {Breaker Sprint (Poseidon) [Water]}
+        And the bot responds with {Your Sprint deals (c:80 r:120) damage on impact and knocks foes away, but uses 5 [mana] per hit}
+
+    Scenario: A user can request information about other boons for a god
+        When the user says to the bot {!poseidon other}
+        Then the bot responds with {[hydraulic might] [fluid gain] [flood control] [double up]}
+
+    Scenario: A user can request information about a god's infusion
+        When the user says to the bot {!poseidon infusion}
+        Then the bot responds with {Water Fitness (Poseidon)}
+        And the bot responds with {If you have at least 4 [water] boons, then gain (c:100) max health}
+
+    Scenario: A user can request information about a god's duos
+        When the user says to the bot {!poseidon duos}
+        Then the bot responds with {[island getaway] [natural selection] [killer current] [seismic hammer] [golden rule] [beach ball] [scalding vapor]}
+
+    Scenario: A user requests an attack for a god who has none
+        Given PENDING
+        When the user says to the bot {!hermes attack}
+        Then the bot responds with {Hermes has no [attack] boon}

--- a/src/commands/boon.ts
+++ b/src/commands/boon.ts
@@ -1,44 +1,28 @@
-import { find, reduce, mapKeys, omitBy } from "lodash";
+import { find, reduce } from "lodash";
 import { Command } from "./command";
 import { gods } from "../data/gods/all";
-import { prereqsFormatter } from "../data/gods/formatters";
+import { abilityFormatter, prereqsFormatter } from "../data/gods/formatters";
+import { Boon } from "../data/gods/god";
 
-const abilityPrereqMap = gods
+type BoonRecord = {
+  god: string;
+  boon: Boon;
+};
+
+const abilityMatchersMap: { [matcher: string]: BoonRecord} = gods
   .map((god) =>
     reduce(
       god.abilities,
       (hash, ability) => ({
         ...hash,
-        [ability.name.replace(" ", " *")]: () => prereqsFormatter(god.name)(ability),
+        [ability.name.replace(" ", " *")]: {god: god.name, boon: ability},
       }), {}
     )
   ).reduce(
     (resultObj, current) => ({ ...resultObj, ...current })
-  ) as { [key: string]: () => string };
+  );
 
-const abilityMap = gods
-  .map((god) =>
-    reduce(
-      god.abilities,
-      (hash, ability, key) => ({
-        ...hash,
-        [ability.name]: god[key as keyof typeof god],
-      }),
-      {}
-    )
-  )
-  .reduce((resultObj, current) => ({ ...resultObj, ...current }));
-
-const abilityMapWithoutNone = omitBy(abilityMap, (value, key) =>
-  /None/i.test(key)
-);
-
-const abilityExpressionMap = mapKeys(abilityMapWithoutNone, (_, abilityName) =>
-  abilityName.replace(" ", " *")
-) as { [key: string]: () => string };
-
-const abilityNameRegexes = Object.keys(abilityExpressionMap).join("|");
-
+const abilityNameRegexes = Object.keys(abilityMatchersMap).join("|");
 const abilityCommand = RegExp(`^(${abilityNameRegexes})( req(?:uirement)?s)?$`, "i");
 
 const boonCommand = new Command({
@@ -48,32 +32,21 @@ const boonCommand = new Command({
   example: "flutter flourish",
   handler: async ({ bot, channelId, commandMatches, logger }) => {
     const abilityName = commandMatches[1];
-    const messageFactory = find(abilityExpressionMap, (_, expressionString) =>
-      RegExp(expressionString, "i").test(abilityName)
+    const boonRecord = find(abilityMatchersMap, (_, matcher) =>
+      RegExp(matcher, "i").test(abilityName)
     );
-    if (!messageFactory) {
+    if (!boonRecord) {
+      logger.debug(`Error. User input matched boonCommand but no boonRecord was found.`);
       return;
     }
 
     const prereqsRequest = commandMatches[2];
     if (prereqsRequest) {
-      const abilityKey = Object.keys(abilityPrereqMap).find((ability) =>
-        RegExp(ability, "i").test(abilityName)
-      ) as keyof typeof abilityPrereqMap;
-      if (!abilityKey) {
-        logger.debug(`Error. Failed to match user input ability ${abilityName} in boonCommand.`);
-        return;
-      }
-
-      const prereqMessage = abilityPrereqMap[abilityKey]();
-      if (!prereqMessage || prereqMessage === "") {
-        return bot.say(channelId, "No known requirements.");
-      }
-
+      const prereqMessage = prereqsFormatter(boonRecord.god)(boonRecord.boon);
       return bot.say(channelId, prereqMessage);
     }
 
-    const message = messageFactory();
+    const message = abilityFormatter(boonRecord.god)(boonRecord.boon);
     bot.say(channelId, message);
   },
 });

--- a/src/commands/boon.ts
+++ b/src/commands/boon.ts
@@ -9,7 +9,7 @@ const abilityPrereqMap = gods
       god.abilities,
       (hash, ability) => ({
         ...hash,
-        [ability.name]: () => prereqsFormatter(god.name)(ability),
+        [ability.name.replace(" ", " *")]: () => prereqsFormatter(god.name)(ability),
       }), {}
     )
   ).reduce(

--- a/src/commands/boon.ts
+++ b/src/commands/boon.ts
@@ -1,7 +1,7 @@
 import { find, reduce } from "lodash";
 import { Command } from "./command";
 import { gods } from "../data/gods/all";
-import { abilityFormatter, prereqsFormatter } from "../data/gods/formatters";
+import { abilityFormatter, prereqsFormatter } from "./utils/formatters";
 import { Boon } from "../data/gods/god";
 
 type BoonRecord = {

--- a/src/commands/god.ts
+++ b/src/commands/god.ts
@@ -8,7 +8,7 @@ import {
   SPECIAL,
 } from "../data/gods/abilityTypes";
 import { gods } from "../data/gods/all";
-import { abilityFormatter } from "../data/gods/formatters";
+import { abilityFormatter } from "./utils/formatters";
 import { Boon } from "../data/gods/god";
 import { DUO } from "../data/gods/rarities";
 import { Command } from "./command";

--- a/src/commands/god.ts
+++ b/src/commands/god.ts
@@ -117,7 +117,7 @@ const godCommand = new Command({
       abilityFilter.filter
     );
     if (filteredAbilities.length === 1) {
-      const message = abilityFormatter(god.name)(filteredAbilities[0])();
+      const message = abilityFormatter(god.name)(filteredAbilities[0]);
       logger.debug("God message " + message);
       return bot.say(channelId, message);
     }

--- a/src/commands/utils/formatters.ts
+++ b/src/commands/utils/formatters.ts
@@ -1,24 +1,14 @@
 import { mapValues, mapKeys } from "lodash";
-import { BoonRarity, abbreviate } from "./rarities";
-import winston from "winston";
-import { BoonElement } from "./elements";
-import { Boon, BoonValues } from "./god";
-
-const logger = winston.createLogger({
-  transports: [new winston.transports.Console()],
-});
-logger.level = process.env.LOG_LEVEL || "debug";
+import { BoonRarity, abbreviate } from "../../data/gods/rarities";
+import { Boon, BoonValues } from "../../data/gods/god";
 
 const summaryFormatter = (values: BoonValues) => {
-  logger.debug(`Values are: ${JSON.stringify(values)}`);
   const baseValues = mapValues(values, (value = {}) =>
     Object.values(value).find(() => true)
   );
-  logger.debug(`Base values are: ${JSON.stringify(baseValues)}`);
-  const abbreviatedKeys = mapKeys(baseValues, (value, key) =>
+  const abbreviatedKeys = mapKeys(baseValues, (_, key) =>
     abbreviate(key as BoonRarity)
   );
-  logger.debug(`Abbreviated values are: ${JSON.stringify(abbreviatedKeys)}`);
   const summarized = mapValues(
     abbreviatedKeys,
     (value, key) => `${key}:${value}`
@@ -28,7 +18,7 @@ const summaryFormatter = (values: BoonValues) => {
 
 const abilityFormatter =
   (god: string) =>
-  ({ name, type, element, info, values, prerequisites }: Boon) => {
+  ({ name, element, info, values, prerequisites }: Boon) => {
     const valueString = summaryFormatter(values);
     // Some boons, like infusions, have no element
     const formattedElement = element ? `[${element}] ` : "";

--- a/src/data/gods/aphrodite.ts
+++ b/src/data/gods/aphrodite.ts
@@ -1,5 +1,3 @@
-import { toArray } from "lodash";
-import { notNullOrUndefined } from "../../utils/arrayUtils";
 import {
   ATTACK,
   CAST,
@@ -12,7 +10,7 @@ import {
 import { lucidGain, novaFlourish, novaStrike, solarRing } from "./apollo";
 import { plentifulForage, winterCoat } from "./demeter";
 import { AIR, COSMIC, WATER } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import { anvilRing, fixedGain, smithySprint } from "./hephaestus";
 import { nastyComeback, nexusSprint, swornFlourish, swornStrike } from "./hera";
 import { hearthGain, smolderRing, sootSprint } from "./hestia";
@@ -341,12 +339,5 @@ export const aphrodite: God = {
   name: "Aphrodite",
   info,
   abilities,
-  elements: [
-    ...new Set(
-      toArray(abilities)
-        .map((ability) => ability.element)
-        .filter((element) => element)
-        .filter(notNullOrUndefined)
-    ),
-  ],
+  elements: listElements(abilities),
 };

--- a/src/data/gods/aphrodite.ts
+++ b/src/data/gods/aphrodite.ts
@@ -341,7 +341,6 @@ export const aphrodite: God = {
   name: "Aphrodite",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
   elements: [
     ...new Set(
       toArray(abilities)

--- a/src/data/gods/aphrodite.ts
+++ b/src/data/gods/aphrodite.ts
@@ -1,4 +1,4 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import { notNullOrUndefined } from "../../utils/arrayUtils";
 import {
   ATTACK,
@@ -12,7 +12,6 @@ import {
 import { lucidGain, novaFlourish, novaStrike, solarRing } from "./apollo";
 import { plentifulForage, winterCoat } from "./demeter";
 import { AIR, COSMIC, WATER } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import { anvilRing, fixedGain, smithySprint } from "./hephaestus";
 import { nastyComeback, nexusSprint, swornFlourish, swornStrike } from "./hera";
@@ -338,7 +337,7 @@ const abilities = {
   wispyWiles,
 };
 
-const base: God = {
+export const aphrodite: God = {
   name: "Aphrodite",
   info,
   abilities,
@@ -352,12 +351,3 @@ const base: God = {
     ),
   ],
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const aphrodite: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { aphrodite };

--- a/src/data/gods/apollo.ts
+++ b/src/data/gods/apollo.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import {
   ATTACK,
   CAST,
@@ -357,5 +356,4 @@ export const apollo: God = {
   name: "Apollo",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/apollo.ts
+++ b/src/data/gods/apollo.ts
@@ -10,7 +10,7 @@ import {
 import { heartBreaker } from "./aphrodite";
 import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
 import { AIR, COSMIC, FIRE } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, nexusSprint } from "./hera";
 import {
@@ -356,4 +356,5 @@ export const apollo: God = {
   name: "Apollo",
   info,
   abilities,
+  elements: listElements(abilities),
 };

--- a/src/data/gods/apollo.ts
+++ b/src/data/gods/apollo.ts
@@ -1,4 +1,4 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import {
   ATTACK,
   CAST,
@@ -11,7 +11,6 @@ import {
 import { heartBreaker } from "./aphrodite";
 import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
 import { AIR, COSMIC, FIRE } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, nexusSprint } from "./hera";
@@ -354,18 +353,9 @@ const abilities = {
   sunWorshiper,
 };
 
-const base: God = {
+export const apollo: God = {
   name: "Apollo",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const apollo: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { apollo };

--- a/src/data/gods/artemis.ts
+++ b/src/data/gods/artemis.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import { OTHER } from "./abilityTypes";
 import { AIR, EARTH } from "./elements";
 import { Boon, God } from "./god";
@@ -120,5 +119,4 @@ export const artemis: God = {
   name: "Artemis",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/artemis.ts
+++ b/src/data/gods/artemis.ts
@@ -1,6 +1,6 @@
 import { OTHER } from "./abilityTypes";
 import { AIR, EARTH } from "./elements";
-import { Boon, God } from "./god";
+import { Boon, God, listElements } from "./god";
 import { COMMON, EPIC, RARE } from "./rarities";
 
 const info =
@@ -119,4 +119,5 @@ export const artemis: God = {
   name: "Artemis",
   info,
   abilities,
+  elements: listElements(abilities),
 };

--- a/src/data/gods/artemis.ts
+++ b/src/data/gods/artemis.ts
@@ -1,7 +1,6 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import { OTHER } from "./abilityTypes";
 import { AIR, EARTH } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God } from "./god";
 import { COMMON, EPIC, RARE } from "./rarities";
 
@@ -117,18 +116,9 @@ const abilities = {
   silverStreak,
 };
 
-const base: God = {
+export const artemis: God = {
   name: "Artemis",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const artemis: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { artemis };

--- a/src/data/gods/demeter.ts
+++ b/src/data/gods/demeter.ts
@@ -6,7 +6,7 @@ import {
 } from "./aphrodite";
 import { blindingSprint, lucidGain, solarRing } from "./apollo";
 import { COSMIC, EARTH, WATER } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, nexusSprint } from "./hera";
 import { flameFlourish, flameStrike } from "./hestia";
@@ -365,4 +365,5 @@ export const demeter: God = {
   name: "Demeter",
   info,
   abilities,
+  elements: listElements(abilities),
 };

--- a/src/data/gods/demeter.ts
+++ b/src/data/gods/demeter.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import {
   healthyRebound,
@@ -366,5 +365,4 @@ export const demeter: God = {
   name: "Demeter",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/demeter.ts
+++ b/src/data/gods/demeter.ts
@@ -1,4 +1,4 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import {
   healthyRebound,
@@ -7,7 +7,6 @@ import {
 } from "./aphrodite";
 import { blindingSprint, lucidGain, solarRing } from "./apollo";
 import { COSMIC, EARTH, WATER } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, nexusSprint } from "./hera";
@@ -363,18 +362,9 @@ const abilities = {
   heartyAppetite,
 };
 
-const base: God = {
+export const demeter: God = {
   name: "Demeter",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const demeter: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { demeter };

--- a/src/data/gods/formatters.ts
+++ b/src/data/gods/formatters.ts
@@ -28,8 +28,7 @@ const summaryFormatter = (values: BoonValues) => {
 
 const abilityFormatter =
   (god: string) =>
-  ({ name, type, element, info, values, prerequisites }: Boon) =>
-  (rarity?: BoonRarity, level?: number) => {
+  ({ name, type, element, info, values, prerequisites }: Boon) => {
     const valueString = summaryFormatter(values);
     // Some boons, like infusions, have no element
     const formattedElement = element ? `[${element}] ` : "";
@@ -40,8 +39,8 @@ const abilityFormatter =
 const prereqsFormatter =
   (god: string) =>
   ({ name, prerequisites }: Boon) => {
-    if (!prerequisites) {
-      return "";
+    if (!prerequisites || prerequisites.length === 0) {
+      return "No known requirements.";
     }
 
     const prereqsString = prerequisites

--- a/src/data/gods/god.ts
+++ b/src/data/gods/god.ts
@@ -1,6 +1,8 @@
+import { toArray } from "lodash";
 import { StandardBoonType, InfusionBoonType, INFUSION } from "./abilityTypes";
 import { BoonElement } from "./elements";
 import { BoonRarity } from "./rarities";
+import { notNullOrUndefined } from "../../utils/arrayUtils";
 
 export type BoonValues = Partial<
   Record<BoonRarity, { [level: number]: string | number }>
@@ -29,5 +31,15 @@ export type God = {
   name: string;
   info: string;
   abilities: { [key: string]: Boon };
-  elements?: BoonElement[];
+  elements: BoonElement[];
+};
+
+export function listElements(abilities: { [key: string]: Boon }): BoonElement[] {
+  return [
+    ...new Set(
+      toArray(abilities)
+        .map((ability) => ability.element)
+        .filter(notNullOrUndefined)
+    ),
+  ];
 };

--- a/src/data/gods/god.ts
+++ b/src/data/gods/god.ts
@@ -29,6 +29,5 @@ export type God = {
   name: string;
   info: string;
   abilities: { [key: string]: Boon };
-  other: Boon[];
   elements?: BoonElement[];
 };

--- a/src/data/gods/hephaestus.ts
+++ b/src/data/gods/hephaestus.ts
@@ -1,10 +1,9 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { novaFlourish, novaStrike, superNova } from "./apollo";
 import { iceFlourish, iceStrike } from "./demeter";
 import { COSMIC, EARTH, FIRE } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import { bornGain, braveFace, keenIntuition, nastyComeback } from "./hera";
 import { flameFlourish, flameStrike, smolderRing } from "./hestia";
@@ -322,18 +321,9 @@ const abilities = {
   masterConductor,
 };
 
-const base: God = {
+export const hephaestus: God = {
   name: "Hephaestus",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const hephaestus: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { hephaestus };

--- a/src/data/gods/hephaestus.ts
+++ b/src/data/gods/hephaestus.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { novaFlourish, novaStrike, superNova } from "./apollo";
@@ -325,5 +324,4 @@ export const hephaestus: God = {
   name: "Hephaestus",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/hephaestus.ts
+++ b/src/data/gods/hephaestus.ts
@@ -3,7 +3,7 @@ import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { novaFlourish, novaStrike, superNova } from "./apollo";
 import { iceFlourish, iceStrike } from "./demeter";
 import { COSMIC, EARTH, FIRE } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import { bornGain, braveFace, keenIntuition, nastyComeback } from "./hera";
 import { flameFlourish, flameStrike, smolderRing } from "./hestia";
 import { geyserRing } from "./poseidon";
@@ -324,4 +324,5 @@ export const hephaestus: God = {
   name: "Hephaestus",
   info,
   abilities,
+  elements: listElements(abilities),
 };

--- a/src/data/gods/hera.ts
+++ b/src/data/gods/hera.ts
@@ -1,10 +1,9 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import { ATTACK, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { blindingSprint, lucidGain, solarRing } from "./apollo";
 import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
 import { COSMIC, EARTH } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import {
   fixedGain,
@@ -346,18 +345,9 @@ const abilities = {
   properUpbringing,
 };
 
-const base: God = {
+export const hera: God = {
   name: "Hera",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const hera: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { hera };

--- a/src/data/gods/hera.ts
+++ b/src/data/gods/hera.ts
@@ -3,7 +3,7 @@ import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { blindingSprint, lucidGain, solarRing } from "./apollo";
 import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
 import { COSMIC, EARTH } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import {
   fixedGain,
   heavyMetal,
@@ -348,4 +348,5 @@ export const hera: God = {
   name: "Hera",
   info,
   abilities,
+  elements: listElements(abilities),
 };

--- a/src/data/gods/hera.ts
+++ b/src/data/gods/hera.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import { ATTACK, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { blindingSprint, lucidGain, solarRing } from "./apollo";
@@ -349,5 +348,4 @@ export const hera: God = {
   name: "Hera",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/hermes.ts
+++ b/src/data/gods/hermes.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import { INFUSION, OTHER } from "./abilityTypes";
 import { AIR, EARTH, FIRE, WATER } from "./elements";
 import { Boon, God, InfusionBoon } from "./god";
@@ -174,5 +173,4 @@ export const hermes: God = {
   name: "Hermes",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/hermes.ts
+++ b/src/data/gods/hermes.ts
@@ -1,6 +1,6 @@
 import { INFUSION, OTHER } from "./abilityTypes";
 import { AIR, EARTH, FIRE, WATER } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import { COMMON, EPIC, LEGENDARY, RARE } from "./rarities";
 
 const info =
@@ -173,4 +173,5 @@ export const hermes: God = {
   name: "Hermes",
   info,
   abilities,
+  elements: listElements(abilities),
 };

--- a/src/data/gods/hermes.ts
+++ b/src/data/gods/hermes.ts
@@ -1,7 +1,6 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import { INFUSION, OTHER } from "./abilityTypes";
 import { AIR, EARTH, FIRE, WATER } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import { COMMON, EPIC, LEGENDARY, RARE } from "./rarities";
 
@@ -171,18 +170,9 @@ const abilities = {
   closeCall,
 };
 
-const base: God = {
+export const hermes: God = {
   name: "Hermes",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const hermes: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { hermes };

--- a/src/data/gods/hestia.ts
+++ b/src/data/gods/hestia.ts
@@ -1,10 +1,9 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { lucidGain, novaFlourish, novaStrike } from "./apollo";
 import { iceFlourish, iceStrike } from "./demeter";
 import { COSMIC, FIRE } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import { volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, swornFlourish, swornStrike } from "./hera";
@@ -372,18 +371,9 @@ const abilities = {
   thermalDynamics,
 };
 
-const base: God = {
+export const hestia: God = {
   name: "Hestia",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const hestia: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { hestia };

--- a/src/data/gods/hestia.ts
+++ b/src/data/gods/hestia.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { lucidGain, novaFlourish, novaStrike } from "./apollo";
@@ -375,5 +374,4 @@ export const hestia: God = {
   name: "Hestia",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/hestia.ts
+++ b/src/data/gods/hestia.ts
@@ -3,7 +3,7 @@ import { glamourGain, passionDash, raptureRing } from "./aphrodite";
 import { lucidGain, novaFlourish, novaStrike } from "./apollo";
 import { iceFlourish, iceStrike } from "./demeter";
 import { COSMIC, FIRE } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import { volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, engagementRing, swornFlourish, swornStrike } from "./hera";
 import { slipperySlope } from "./poseidon";
@@ -374,4 +374,5 @@ export const hestia: God = {
   name: "Hestia",
   info,
   abilities,
+  elements: listElements(abilities),
 };

--- a/src/data/gods/poseidon.ts
+++ b/src/data/gods/poseidon.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import { flutterFlourish, flutterStrike } from "./aphrodite";
 import { blindingSprint, lucidGain } from "./apollo";
@@ -375,5 +374,4 @@ export const poseidon: God = {
   name: "Poseidon",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/poseidon.ts
+++ b/src/data/gods/poseidon.ts
@@ -1,4 +1,4 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
 import { flutterFlourish, flutterStrike } from "./aphrodite";
 import { blindingSprint, lucidGain } from "./apollo";
@@ -10,7 +10,6 @@ import {
   winterCoat,
 } from "./demeter";
 import { COSMIC, WATER } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, nexusSprint, swornStrike } from "./hera";
@@ -372,18 +371,9 @@ const abilities = {
   scaldingVapor,
 };
 
-const base: God = {
+export const poseidon: God = {
   name: "Poseidon",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const poseidon: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { poseidon };

--- a/src/data/gods/poseidon.ts
+++ b/src/data/gods/poseidon.ts
@@ -9,7 +9,7 @@ import {
   winterCoat,
 } from "./demeter";
 import { COSMIC, WATER } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
 import { bornGain, nexusSprint, swornStrike } from "./hera";
 import {
@@ -374,4 +374,5 @@ export const poseidon: God = {
   name: "Poseidon",
   info,
   abilities,
+  elements: listElements(abilities),
 };

--- a/src/data/gods/zeus.ts
+++ b/src/data/gods/zeus.ts
@@ -1,4 +1,3 @@
-import { toArray } from "lodash";
 import {
   ATTACK,
   CAST,
@@ -381,5 +380,4 @@ export const zeus: God = {
   name: "Zeus",
   info,
   abilities,
-  other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };

--- a/src/data/gods/zeus.ts
+++ b/src/data/gods/zeus.ts
@@ -1,4 +1,4 @@
-import { mapValues, toArray } from "lodash";
+import { toArray } from "lodash";
 import {
   ATTACK,
   CAST,
@@ -17,7 +17,6 @@ import {
 import { solarRing } from "./apollo";
 import { arcticRing, frigidSprint, iceFlourish, iceStrike } from "./demeter";
 import { AIR, COSMIC } from "./elements";
-import { abilityFormatter } from "./formatters";
 import { Boon, God, InfusionBoon } from "./god";
 import {
   fixedGain,
@@ -378,18 +377,9 @@ const abilities = {
   romanticSpark,
 };
 
-const base: God = {
+export const zeus: God = {
   name: "Zeus",
   info,
   abilities,
   other: toArray(abilities).filter((ability) => ability.type === OTHER),
 };
-
-const formattedAbilities = mapValues(abilities, abilityFormatter(base.name));
-
-const zeus: God = {
-  ...base,
-  ...formattedAbilities,
-};
-
-export { zeus };

--- a/src/data/gods/zeus.ts
+++ b/src/data/gods/zeus.ts
@@ -16,7 +16,7 @@ import {
 import { solarRing } from "./apollo";
 import { arcticRing, frigidSprint, iceFlourish, iceStrike } from "./demeter";
 import { AIR, COSMIC } from "./elements";
-import { Boon, God, InfusionBoon } from "./god";
+import { Boon, God, InfusionBoon, listElements } from "./god";
 import {
   fixedGain,
   heavyMetal,
@@ -380,4 +380,5 @@ export const zeus: God = {
   name: "Zeus",
   info,
   abilities,
+  elements: listElements(abilities),
 };


### PR DESCRIPTION
- Fixes bug in the boon command that caused `ecstaticObsession` and `ecstatic obsession reqs` to work but `ecstaticObsession reqs` to fail
- De-dupes fragile code that made this possible and cleans up boon command overall
- Moves all bot-output-string-formatting logic to /commands/utils and removes all references to formatters in /data
- Removes obsolete `other` property from the god type definition and gods' data
- Defines a utility function for gods to populate the `elements` property, makes use of it to populate `elements` for all gods, and makes this property mandatory henceforth
- Adds a few scenarios to test fixed / improved boons command