### PR TITLE
Add Chaos

### DIFF
--- a/features/boons.feature
+++ b/features/boons.feature
@@ -45,3 +45,8 @@ Feature: A user can request information about a specific boon
         Given PENDING
         When the user says to the bot {!golden rule}
         Then the bot responds with {this is broken; chooses one of the two gods}
+
+    Scenario: A user asks for Chaos' infusion
+        When the user says to the bot {!chant}
+        Then the bot responds with {Chant (Chaos)}
+        And the bot responds with {Afterward, your [omega] moves deal (c:30% r:36% e:42% h:48%) more damage per [cosmic] you have}

--- a/features/chaos.feature
+++ b/features/chaos.feature
@@ -1,0 +1,31 @@
+Feature: Users can request information about infusions
+    Background:
+        Given a user {user1}
+        And a channel {sneakyteak}
+
+    Scenario: Users can request a Chaos combo
+        When the user says to the bot {!addled blood}
+        Then the bot responds with {For the next 3-5 Encounters, each time you use your Cast, get hit for 3-6 damage}
+        And the bot responds with {Afterward, whenever you exit a Location, restore (c:3-4 r:9-12 e:15-20 h:21-28) health.}
+
+    Scenario: Users can request a curse and blessing with percentages
+        When the user says to the bot {!excruciating chasm}
+        Then the bot responds with {For the next 3-5 Encounters, you take 20%-50% increased damage.}
+        And the bot responds with {Afterward, your Casts deal (c:20%-50% r:30%-75% e:40%-100% h:50%-125%) more damage.}
+
+    Scenario: Users can request a curse with special characters
+        When the user says to the bot {!pauper's blood}
+        Then the bot responds with {For the next 3-5 Encounters, you cannot earn money.}
+
+    Scenario: Users can request a curse with alternate duration and no value
+        When the user says to the bot {!rejected blood}
+        Then the bot responds with {Your next 2-4 Boons you find will have 1 fewer blessing to choose from.}
+
+    Scenario: Users can request the legendary blessing
+        When the user says to the bot {!addled defiance}
+        Then the bot responds with {Afterward, gain (l:1) uses of Death Defiance this night.}
+
+    Scenario: Users can request a Chaos combo with alternate case
+        When the user says to the bot {!AdDlEd bLooD}
+        Then the bot responds with {For the next 3-5 Encounters, each time you use your Cast, get hit for 3-6 damage}
+        And the bot responds with {Afterward, whenever you exit a Location, restore (c:3-4 r:9-12 e:15-20 h:21-28) health.}

--- a/features/gods.feature
+++ b/features/gods.feature
@@ -47,3 +47,8 @@ Feature: Requests about gods and their boons
         Given PENDING
         When the user says to the bot {!hermes attack}
         Then the bot responds with {Hermes has no [attack] boon}
+
+    Scenario: A user can request Chaos' infusion
+        When the user says to the bot {!chaos infusion}
+        Then the bot responds with {Chant (Chaos)}
+        And the bot responds with {Afterward, your [omega] moves deal (c:30% r:36% e:42% h:48%) more damage per [cosmic] you have}

--- a/features/infusions.feature
+++ b/features/infusions.feature
@@ -8,8 +8,13 @@ Feature: Users can request information about infusions
         Then the bot responds with {Infusions are a special type of boon}
         And the bot responds with {[Earth] [Water] [Air] [Fire] [Cosmic]}
 
-    Scenario: Users can request available infusions for an element
+    Scenario: Users can request available infusions for a base element
         When the user says to the bot {!infusions air}
         Then the bot responds with {Infusions that require at least one [Air]}
         And the bot responds with {Wispy Wiles (Aphrodite)}
         And the bot responds with {Tall Order (Hermes)}
+
+    Scenario: Users can request available cosmic infusions
+        When the user says to the bot {!infusions cosmic}
+        Then the bot responds with {Infusions that require at least one [Cosmic]}
+        And the bot responds with {Chant (Chaos)}

--- a/src/commands/all.ts
+++ b/src/commands/all.ts
@@ -12,6 +12,7 @@ import { elementListCommand } from "./elementList";
 import { hexCommand } from "./hex";
 import { hexListCommand } from "./hexList";
 import { infusionCommand } from "./infusion";
+import { chaosCommand } from "./chaosBoons";
 
 const allCommands = [
   pingCommand,
@@ -28,5 +29,6 @@ const allCommands = [
   hexCommand,
   hexListCommand,
   infusionCommand,
+  chaosCommand,
 ];
 export { allCommands };

--- a/src/commands/chaosBoons.ts
+++ b/src/commands/chaosBoons.ts
@@ -1,0 +1,55 @@
+import { find, reduce, mapKeys, omitBy } from "lodash";
+import { Command } from "./command";
+import { gods } from "../data/gods/all";
+import { curses, blessings } from "../data/chaos";
+
+const abilityMap = gods
+  .map((god) =>
+    reduce(
+      god.abilities,
+      (hash, ability, key) => ({
+        ...hash,
+        [ability.name]: god[key as keyof typeof god],
+      }),
+      {}
+    )
+  )
+  .reduce((resultObj, current) => ({ ...resultObj, ...current }));
+
+const abilityMapWithoutNone = omitBy(abilityMap, (value, key) =>
+  /None/i.test(key)
+);
+
+const abilityExpressionMap = mapKeys(abilityMapWithoutNone, (_, abilityName) =>
+  abilityName.replace(" ", " *")
+) as { [key: string]: () => string };
+
+const curseRegexes = /attack/i;
+const blessingRegexes = /special/i;
+
+const chaosBoonsCommand = RegExp(
+  `^(${curseRegexes}) (${blessingRegexes})$`,
+  "i"
+);
+
+const boonCommand = new Command({
+  command: chaosBoonsCommand,
+  name: "Chaos Boons",
+  test: true,
+  example: "flutter flourish",
+  handler: async ({ bot, channelId, commandMatches, logger }) => {
+    const curseName = commandMatches[1];
+    const blessingName = commandMatches[2];
+    const curse = curses.find((curse) => curse.matcher.test(curseName));
+    const blessing = blessings.find((blessing) =>
+      blessing.matcher.test(blessingName)
+    );
+    if (!curse || !blessing) {
+      return;
+    }
+    const message = "Pasta";
+    bot.say(channelId, message);
+  },
+});
+
+export { boonCommand };

--- a/src/commands/chaosBoons.ts
+++ b/src/commands/chaosBoons.ts
@@ -1,42 +1,43 @@
-import { find, reduce, mapKeys, omitBy } from "lodash";
+import { reduce } from "lodash";
 import { Command } from "./command";
-import { gods } from "../data/gods/all";
-import { curses, blessings } from "../data/chaos";
+import { curses, blessings, ChaosCurseValues } from "../data/chaos";
+import { BoonRarity, abbreviate } from "../data/gods/rarities";
 
-const abilityMap = gods
-  .map((god) =>
-    reduce(
-      god.abilities,
-      (hash, ability, key) => ({
-        ...hash,
-        [ability.name]: god[key as keyof typeof god],
-      }),
-      {}
-    )
-  )
-  .reduce((resultObj, current) => ({ ...resultObj, ...current }));
-
-const abilityMapWithoutNone = omitBy(abilityMap, (value, key) =>
-  /None/i.test(key)
+// WIP: Given that we are stripping the flags from these regex literals,
+// it's not clear that they should be regex in the first place. After all,
+// the only flag we end up adding back is i, the case insensitive flag.
+const curseRegexes = curses.reduce(
+  (currentMatchers, curse) => {
+    if (currentMatchers === "") {
+      return curse.matcher.source;
+    }
+    
+    return currentMatchers + "|" + curse.matcher.source;
+  }, ""
 );
 
-const abilityExpressionMap = mapKeys(abilityMapWithoutNone, (_, abilityName) =>
-  abilityName.replace(" ", " *")
-) as { [key: string]: () => string };
-
-const curseRegexes = /attack/i;
-const blessingRegexes = /special/i;
+const blessingRegexes = blessings.reduce(
+  (currentMatchers, blessing) => {
+    if (currentMatchers === "") {
+      return blessing.matcher.source;
+    }
+    
+    return currentMatchers + "|" + blessing.matcher.source;
+  }, ""
+);
 
 const chaosBoonsCommand = RegExp(
   `^(${curseRegexes}) (${blessingRegexes})$`,
   "i"
 );
 
-const boonCommand = new Command({
+console.log(`COMMAND: ${chaosBoonsCommand}`);
+
+const chaosCommand = new Command({
   command: chaosBoonsCommand,
   name: "Chaos Boons",
-  test: true,
-  example: "flutter flourish",
+  test: false,
+  example: "addled blood",
   handler: async ({ bot, channelId, commandMatches, logger }) => {
     const curseName = commandMatches[1];
     const blessingName = commandMatches[2];
@@ -47,9 +48,84 @@ const boonCommand = new Command({
     if (!curse || !blessing) {
       return;
     }
-    const message = "Pasta";
+
+    // WIP: Compose this mess into utility functions somehow. Can we merge
+    // with some existing formatters?
+    // I bet we can make this:
+    // const rangeString (min, max, mult, asPercent)
+    // and use that for all of the ranges.
+    const curseString = (values: ChaosCurseValues) => {
+      if (values.value) {
+        const min = values.value.min;
+        const minString = values.asPercent ?
+          Math.round(min * 100) + "%" :
+          `${min}`;
+        const max = values.value.max;
+        if (min !== max) {
+          const maxString = values.asPercent ?
+            Math.round(max * 100) + "%" :
+            `${max}`;
+          return minString + "-" + maxString
+        } else {
+          return minString;
+        }
+      } else {
+        return "";
+      }
+    }
+
+    const curseValue = curseString(curse.values);
+
+    const curseDuration =
+      curse.values.duration.min + "-" + curse.values.duration.max;
+
+    const curseMessage = curse.info(curseValue, curseDuration);
+
+    type BlessingRecord = {
+      min: number;
+      max: number;
+    };
+
+    const rarityAdjustedValues = reduce(
+      blessing.values.rarityMultipliers, (hash, mult, key) => {
+        if (!mult) {
+          return hash;
+        }
+        const record = {
+          min: mult * blessing.values.baseMin,
+          max: mult * blessing.values.baseMax
+        }
+        return { ...hash, [key]: record };
+      }, {} as Record<string, BlessingRecord>
+    );
+
+    const formattedValues = reduce(
+      rarityAdjustedValues, (array, record, key) => {
+        var value = abbreviate(key as BoonRarity);
+        // WIP: Can we capture all of this as an anonymous function
+        var min = `${record.min}`;
+        var max = `${record.max}`;
+        if (blessing.values.asPercent) {
+          min = Math.round(record.min * 100) + "%";
+          max = Math.round(record.max * 100) + "%";
+        }
+
+        value = value + ":" + min;
+        if (blessing.values.baseMin === blessing.values.baseMax) {
+          return [ ...array, value ];
+        }
+        
+        value = value + "-" + max;
+        return [ ...array, value ];
+      }, [] as string[]
+    );
+
+    const blessingValue = "(" + formattedValues.join(" ") + ")";
+    const blessingMessage = blessing.info(blessingValue);
+
+    const message = `${curseMessage} ${blessingMessage}`;
     bot.say(channelId, message);
   },
 });
 
-export { boonCommand };
+export { chaosCommand };

--- a/src/commands/chaosBoons.ts
+++ b/src/commands/chaosBoons.ts
@@ -1,37 +1,16 @@
-import { reduce } from "lodash";
+import { map } from "lodash";
 import { Command } from "./command";
-import { curses, blessings, ChaosCurseValues } from "../data/chaos";
+import { curses, blessings, Range } from "../data/chaos";
 import { BoonRarity, abbreviate } from "../data/gods/rarities";
 
-// WIP: Given that we are stripping the flags from these regex literals,
-// it's not clear that they should be regex in the first place. After all,
-// the only flag we end up adding back is i, the case insensitive flag.
-const curseRegexes = curses.reduce(
-  (currentMatchers, curse) => {
-    if (currentMatchers === "") {
-      return curse.matcher.source;
-    }
-    
-    return currentMatchers + "|" + curse.matcher.source;
-  }, ""
-);
-
-const blessingRegexes = blessings.reduce(
-  (currentMatchers, blessing) => {
-    if (currentMatchers === "") {
-      return blessing.matcher.source;
-    }
-    
-    return currentMatchers + "|" + blessing.matcher.source;
-  }, ""
-);
+const curseRegexes = curses.map((curse) => curse.matcher.source).join("|");
+const blessingRegexes =
+  blessings.map((blessing) => blessing.matcher.source).join("|");
 
 const chaosBoonsCommand = RegExp(
   `^(${curseRegexes}) (${blessingRegexes})$`,
   "i"
 );
-
-console.log(`COMMAND: ${chaosBoonsCommand}`);
 
 const chaosCommand = new Command({
   command: chaosBoonsCommand,
@@ -46,79 +25,44 @@ const chaosCommand = new Command({
       blessing.matcher.test(blessingName)
     );
     if (!curse || !blessing) {
+      const err = "User input matched chaosCommand but no curse or blessing " +
+        "was identified.";
+      logger.alert(err);
       return;
     }
 
-    // WIP: Compose this mess into utility functions somehow. Can we merge
-    // with some existing formatters?
-    // I bet we can make this:
-    // const rangeString (min, max, mult, asPercent)
-    // and use that for all of the ranges.
-    const curseString = (values: ChaosCurseValues) => {
-      if (values.value) {
-        const min = values.value.min;
-        const minString = values.asPercent ?
-          Math.round(min * 100) + "%" :
-          `${min}`;
-        const max = values.value.max;
-        if (min !== max) {
-          const maxString = values.asPercent ?
-            Math.round(max * 100) + "%" :
-            `${max}`;
-          return minString + "-" + maxString
-        } else {
-          return minString;
+    const rangeString =
+      (range: Range | undefined, asPercent = false, mult = 1) => {
+        if (!range) {
+          return "";
         }
-      } else {
-        return "";
-      }
-    }
 
-    const curseValue = curseString(curse.values);
+        const scaledMin = range.min * mult;
+        const minString = asPercent ?
+          Math.round(scaledMin * 100) + "%" :
+          `${scaledMin}`;
+        if (range.min === range.max) {
+          return minString
+        }
 
-    const curseDuration =
-      curse.values.duration.min + "-" + curse.values.duration.max;
+        const scaledMax = range.max * mult;
+        const maxString = asPercent ?
+          Math.round(scaledMax * 100) + "%" :
+          `${scaledMax}`;
+        return minString + "-" + maxString;
+      };
 
+    const curseValue = rangeString(curse.values.value, curse.values.asPercent);
+    const curseDuration = rangeString(curse.values.duration);
     const curseMessage = curse.info(curseValue, curseDuration);
 
-    type BlessingRecord = {
-      min: number;
-      max: number;
-    };
-
-    const rarityAdjustedValues = reduce(
-      blessing.values.rarityMultipliers, (hash, mult, key) => {
-        if (!mult) {
-          return hash;
-        }
-        const record = {
-          min: mult * blessing.values.baseMin,
-          max: mult * blessing.values.baseMax
-        }
-        return { ...hash, [key]: record };
-      }, {} as Record<string, BlessingRecord>
-    );
-
-    const formattedValues = reduce(
-      rarityAdjustedValues, (array, record, key) => {
-        var value = abbreviate(key as BoonRarity);
-        // WIP: Can we capture all of this as an anonymous function
-        var min = `${record.min}`;
-        var max = `${record.max}`;
-        if (blessing.values.asPercent) {
-          min = Math.round(record.min * 100) + "%";
-          max = Math.round(record.max * 100) + "%";
-        }
-
-        value = value + ":" + min;
-        if (blessing.values.baseMin === blessing.values.baseMax) {
-          return [ ...array, value ];
-        }
-        
-        value = value + "-" + max;
-        return [ ...array, value ];
-      }, [] as string[]
-    );
+    const formattedValues: string[] =
+      map(blessing.values.rarityMultipliers, (mult, key) => {
+        const shortRarity = abbreviate(key as BoonRarity);
+        const rarityValues =
+          rangeString(blessing.values.base, blessing.values.asPercent, mult);
+        return shortRarity + ":" + rarityValues;
+      });
 
     const blessingValue = "(" + formattedValues.join(" ") + ")";
     const blessingMessage = blessing.info(blessingValue);

--- a/src/commands/infusion.ts
+++ b/src/commands/infusion.ts
@@ -1,7 +1,6 @@
-import { find } from "lodash";
 import { gods } from "../data/gods/all";
 import { AIR, BoonElement, COSMIC, EARTH, FIRE, WATER } from "../data/gods/elements";
-import { InfusionBoon, isInfusion } from "../data/gods/god";
+import { isInfusion } from "../data/gods/god";
 import { Command } from "./command";
 
 const allElements = [EARTH, WATER, AIR, FIRE, COSMIC];

--- a/src/data/chaos.ts
+++ b/src/data/chaos.ts
@@ -1,0 +1,378 @@
+import { INFUSION } from "./gods/abilityTypes";
+import { COSMIC } from "./gods/elements";
+import { God, InfusionBoon } from "./gods/god";
+import { COMMON, RARE, EPIC, LEGENDARY } from "./gods/rarities";
+
+type ChaosCurseValues = {
+  [COMMON]?: { value: string | number; duration: number };
+  [RARE]?: { value: string | number; duration: number };
+  [EPIC]?: { value: string | number; duration: number };
+};
+
+type ChaosCurse = {
+  name: string;
+  type: "curse" | "blessing";
+  matcher: RegExp;
+  info: (value: string | number, duration: number) => string;
+  values: ChaosCurseValues;
+};
+
+type ChaosBlessingValues = {
+  [COMMON]?: { value: string | number };
+  [RARE]?: { value: string | number };
+  [EPIC]?: { value: string | number };
+  [LEGENDARY]?: { value: string | number };
+};
+
+type ChaosBlessing = {
+  name: string;
+  type: "blessing";
+  matcher: RegExp;
+  info: (value: string | number) => string;
+  values: ChaosBlessingValues;
+};
+
+const chant: InfusionBoon = {
+  name: "Chant",
+  type: INFUSION,
+  requiredElements: [COSMIC],
+  info: (value) =>
+    `Afterward, your [omega] moves deal ${value} more damage per [cosmic] you have`,
+  values: {
+    [COMMON]: { 1: "30%" },
+  },
+};
+
+export const chaos: God = {
+  name: "Chaos",
+  info: "Primordial god of the abyss. His boons are provide powerful blessings, if you can survive their curses",
+  abilities: {},
+  other: [chant],
+};
+
+export const curses: ChaosCurse[] = [
+  {
+    name: "Addled",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, each time you use your Cast, get hit for ${value} damage`,
+    matcher: /addled/i,
+    values: {
+      [COMMON]: { value: 6, duration: 5 },
+    },
+  },
+  {
+    name: "Ordinary",
+    type: "curse",
+    info: (value, duration) =>
+      `The next ${value} Boons you find are limited to ${value} blessings`,
+    matcher: /ordinary/i,
+    values: {
+      [COMMON]: { value: 6, duration: 5 },
+    },
+  },
+  {
+    name: "Excruciating",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, you take ${value} increased damage`,
+    matcher: /excruciating/i,
+    values: {
+      [COMMON]: { value: "34%", duration: 3 },
+    },
+  },
+  {
+    name: "Hobbled",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, your Dash is slower and uses ${value} mana (if you have it)`,
+    matcher: /hobbled/i,
+    values: {
+      [COMMON]: { value: 5, duration: 5 },
+    },
+  },
+  {
+    name: "Caustic",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, slain foes toss and Inferno Bomb at you`,
+    matcher: /caustic/i,
+    values: {
+      [COMMON]: { value: "", duration: 4 },
+    },
+  },
+  {
+    name: "Gagged",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, each time you use [omega] moves, get hit for ${value} damage`,
+    matcher: /gagged/i,
+    values: {
+      [COMMON]: { value: 6, duration: 3 },
+    },
+  },
+  {
+    name: "Atrophic",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, you have ${value} less max health`,
+    matcher: /atrophic/i,
+    values: {
+      [COMMON]: { value: 26, duration: 5 },
+    },
+  },
+  {
+    name: "Enshrouded",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, your Location Reward previews are hidden`,
+    matcher: /enshrouded/i,
+    values: {
+      [COMMON]: { value: "", duration: 5 },
+    },
+  },
+  {
+    name: "Fixated",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, whenever you use [mana] prime it`,
+    matcher: /fixated/i,
+    values: {
+      [COMMON]: { value: "", duration: 4 },
+    },
+  },
+  {
+    name: "Barren",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, your arcana cards have no effect`,
+    matcher: /barren/i,
+    values: {
+      [COMMON]: { value: "", duration: 9 },
+    },
+  },
+  {
+    name: "Pauper's",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, you cannot earn money`,
+    matcher: /pauper'?s/i,
+    values: {
+      [COMMON]: { value: "", duration: 3 },
+    },
+  },
+  {
+    name: "Maimed",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, each time you use Attacks, get hit for ${value} damage`,
+    matcher: /maimed/i,
+    values: {
+      [COMMON]: { value: 5, duration: 5 },
+    },
+  },
+  {
+    name: "Rejected",
+    type: "curse",
+    info: (value, duration) =>
+      `Your next ${duration} Boons you find will have ${value} fewer blessings to choose from`,
+    matcher: /rejected/i,
+    values: {
+      [COMMON]: { value: 1, duration: 2 },
+    },
+  },
+  {
+    name: "Flayed",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, each time you use Specials, get hit for ${value} damage`,
+    matcher: /flayed/i,
+    values: {
+      [COMMON]: { value: 4, duration: 3 },
+    },
+  },
+  {
+    name: "Slothful",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, you move and Sprint ${value} slower`,
+    matcher: /slothful/i,
+    values: {
+      [COMMON]: { value: "44%", duration: 4 },
+    },
+  },
+  {
+    name: "Paralyzing",
+    type: "curse",
+    info: (value, duration) =>
+      `For the next ${duration} Encounters, whenever you take damage, you are stunned for ${value} seconds`,
+    matcher: /Paralyzing/i,
+    values: {
+      [COMMON]: { value: 1.2, duration: 3 },
+    },
+  },
+  {
+    name: "Doomed",
+    type: "curse",
+    info: (value, duration) =>
+      `You have ${value} seconds to clear ${duration} Encounters, or get hit for 500 damage`,
+    matcher: /Doomed/i,
+    values: {
+      [COMMON]: { value: 120, duration: 3 },
+    },
+  },
+];
+
+export const blessings: ChaosBlessing[] = [
+  {
+    name: "Chasm",
+    type: "blessing",
+    info: (value) => `Afterward, your Casts deal ${value} damage`,
+    matcher: /Chasm/i,
+    values: {
+      [COMMON]: { value: "39%" },
+    },
+  },
+  {
+    name: "Blood",
+    type: "blessing",
+    info: (value) =>
+      `Afterward, whenever you exit a Location, restore ${value} health`,
+    matcher: /Blood/i,
+    values: {
+      [COMMON]: { value: 3 },
+    },
+  },
+  {
+    name: "Creation",
+    type: "blessing",
+    info: (value) =>
+      `Afterward, gain ${value} [earth] [water] [air] [fire] [cosmic]`,
+    matcher: /creation/i,
+    values: {
+      [COMMON]: { value: 1 },
+    },
+  },
+  {
+    name: "Revelation",
+    type: "blessing",
+    info: (value) =>
+      `Afterward, you Channel  your [omega] Moves ${value} faster`,
+    matcher: /revelation/i,
+    values: {
+      [COMMON]: { value: "12%" },
+    },
+  },
+  {
+    name: "Discovery",
+    type: "blessing",
+    info: (value) =>
+      `Afterward, you have a ${value} chance to find +100% resources with your Gathering Tools`,
+    matcher: /discovery/i,
+    values: {
+      [COMMON]: { value: "58%" },
+    },
+  },
+  {
+    name: "Soul",
+    type: "blessing",
+    info: (value) => `Afterward, you get +${value} max health`,
+    matcher: /soul/i,
+    values: {
+      [COMMON]: { value: 29 },
+    },
+  },
+  {
+    name: "Mind",
+    type: "blessing",
+    info: (value) => `Afterward, you get +${value} max [mana]`,
+    matcher: /mind/i,
+    values: {
+      [COMMON]: { value: 37 },
+    },
+  },
+  {
+    name: "Talent",
+    type: "blessing",
+    info: (value) => `Afterward, you use ${value} less mana`,
+    matcher: /talent/i,
+    values: {
+      [COMMON]: { value: "30%" },
+    },
+  },
+  {
+    name: "Will",
+    type: "blessing",
+    info: (value) => `Afterward, restore ${value} mana every 1 second`,
+    matcher: /will/i,
+    values: {
+      [COMMON]: { value: 5 },
+    },
+  },
+  {
+    name: "Affluence",
+    type: "blessing",
+    info: (value) => `Afterward, any [gold] you find is worth ${value} more`,
+    matcher: /Affluence/i,
+    values: {
+      [COMMON]: { value: "55%" },
+    },
+  },
+  {
+    name: "Favor",
+    type: "blessing",
+    info: (value) =>
+      `Afterward, Boons have a ${value} chance to be Rare or better`,
+    matcher: /favor/i,
+    values: {
+      [COMMON]: { value: "41%" },
+    },
+  },
+  {
+    name: "Flourish",
+    type: "blessing",
+    info: (value) => `Afterward, your Specials deal ${value} more damage`,
+    matcher: /Flourish/i,
+    values: {
+      [COMMON]: { value: "32%" },
+    },
+  },
+  {
+    name: "Celerity",
+    type: "blessing",
+    info: (value) => `Afterward, you move and Sprint ${value} faster`,
+    matcher: /Celerity/i,
+    values: {
+      [COMMON]: { value: "15%" },
+    },
+  },
+  {
+    name: "Strike",
+    type: "blessing",
+    info: (value) => `Afterward, your Attacks deal ${value} more damage`,
+    matcher: /Strike/i,
+    values: {
+      [COMMON]: { value: "23%" },
+    },
+  },
+  {
+    name: "Chant",
+    type: "blessing",
+    info: (value) =>
+      `Afterward, your [omega] moves deal ${value} more damage per [cosmic] you have`,
+    matcher: /Chant/i,
+    values: {
+      [COMMON]: { value: "30%" },
+    },
+  },
+  {
+    name: "Defiance",
+    type: "blessing",
+    info: (value) =>
+      `Afterward, gain ${value} uses of Death Defiance this night`,
+    matcher: /Defiance/i,
+    values: {
+      [LEGENDARY]: { value: 1 },
+    },
+  },
+];

--- a/src/data/chaos.ts
+++ b/src/data/chaos.ts
@@ -1,37 +1,89 @@
 import { INFUSION } from "./gods/abilityTypes";
 import { COSMIC } from "./gods/elements";
 import { God, InfusionBoon } from "./gods/god";
-import { COMMON, RARE, EPIC, LEGENDARY } from "./gods/rarities";
+import { COMMON, RARE, EPIC, HEROIC, LEGENDARY } from "./gods/rarities";
 
-type ChaosCurseValues = {
-  [COMMON]?: { value: string | number; duration: number };
-  [RARE]?: { value: string | number; duration: number };
-  [EPIC]?: { value: string | number; duration: number };
+type Range = {
+  min: number;
+  max: number;
+};
+
+// WIP: type / interface ChaosTrait which guarantees name, type, matcher, info, and values?
+// values are ChaosBlessingValues | ChaosCurseValues? info takes one or two params?
+
+export type ChaosCurseValues = {
+  // WIP: How much utility do we get out of Range as a type here?
+  // It cleans up this definition, but it also adds another layer of object to
+  // unpack. Whatever we do, we should probably align how ChaosCurseValues
+  // and ChaosBlessingValues work. (This will also facilitate some shared
+  // formatter code.)
+  value?: Range;
+  duration: Range;
+
+  // This is a formatter flag that indicates whether the values should be
+  // presented as percentages after calculations are done. This breaks
+  // encapsulation between data and formatting, but it allows us to store
+  // all values as numbers and to do math on them.
+  asPercent: boolean;
+};
+
+const defaultDuration: Range = {
+  min: 3,
+  max: 5
 };
 
 type ChaosCurse = {
+  // Commented object name in game source code, where known
   name: string;
-  type: "curse" | "blessing";
+  // WIP: Capture types in global constant, if they are used at all.
+  type: "curse";
   matcher: RegExp;
-  info: (value: string | number, duration: number) => string;
+  // WIP: Would it help to give the info() params different names?
+  info: (value: string, duration: string) => string;
   values: ChaosCurseValues;
 };
 
+
+// WIP: Should rarityMultipliers mimic the BoonValues Partial in god.ts?
+// Almost all Chaos blessings have a range of values.
 type ChaosBlessingValues = {
-  [COMMON]?: { value: string | number };
-  [RARE]?: { value: string | number };
-  [EPIC]?: { value: string | number };
-  [LEGENDARY]?: { value: string | number };
+  // Should this just be a Range?
+  baseMin: number;
+  baseMax: number;
+  rarityMultipliers: {
+    [COMMON]?: number;
+    [RARE]?: number;
+    [EPIC]?: number;
+    [HEROIC]?: number;
+    [LEGENDARY]?: number;
+  };
+
+  // See ChaosCurseValues.asPercent
+  asPercent: boolean;
 };
 
+const defaultRarityMultipliers = {
+  [COMMON]: 1.0,
+  [RARE]: 1.5,
+  [EPIC]: 2.0,
+  [HEROIC]: 2.5,
+};
+
+// WIP: Should this be "boonish"?
 type ChaosBlessing = {
+  // Commented object name in game source code, where known
   name: string;
   type: "blessing";
   matcher: RegExp;
-  info: (value: string | number) => string;
+  info: (value: string) => string;
   values: ChaosBlessingValues;
 };
 
+// Chant is a blessing but should _also_ be queriable as an Infusion-type Boon.
+// To achieve this, we export a Chaos God object with only one "Boon".
+// Technically, this boon has a prereq: The user must have at least one other
+// Chaos blessing in the current run. Implementing this will require some type
+// of refactor given that prerequisites expects a list of Boons.
 const chant: InfusionBoon = {
   name: "Chant",
   type: INFUSION,
@@ -40,339 +92,497 @@ const chant: InfusionBoon = {
     `Afterward, your [omega] moves deal ${value} more damage per [cosmic] you have`,
   values: {
     [COMMON]: { 1: "30%" },
+    [RARE]: { 1: "36%" },
+    [EPIC]: { 1: "42%" },
+    [HEROIC]: { 1: "48%" },
   },
 };
 
 export const chaos: God = {
   name: "Chaos",
-  info: "Primordial god of the abyss. His boons are provide powerful blessings, if you can survive their curses",
-  abilities: {},
-  other: [chant],
+  info: "Primordial god of the abyss. His boons provide powerful blessings, if you can survive their curses.",
+  abilities: {chant},
+  elements: [],
 };
 
 export const curses: ChaosCurse[] = [
   {
+    // ChaosCastCurse
     name: "Addled",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, each time you use your Cast, get hit for ${value} damage`,
+      `For the next ${duration} Encounters, each time you use your Cast, get hit for ${value} damage.`,
     matcher: /addled/i,
     values: {
-      [COMMON]: { value: 6, duration: 5 },
+      value: { min: 3, max: 6 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosCommonCurse
     name: "Ordinary",
     type: "curse",
-    info: (value, duration) =>
-      `The next ${value} Boons you find are limited to ${value} blessings`,
+    info: (_, duration) =>
+      `The next ${duration} Boons you find are limited to common blessings.`,
     matcher: /ordinary/i,
     values: {
-      [COMMON]: { value: 6, duration: 5 },
+      duration: { min: 2, max: 3 },
+      asPercent: false,
     },
   },
   {
+    // ChaosDamageCurse
     name: "Excruciating",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, you take ${value} increased damage`,
+      `For the next ${duration} Encounters, you take ${value} increased damage.`,
     matcher: /excruciating/i,
     values: {
-      [COMMON]: { value: "34%", duration: 3 },
+      value: { min: 0.2, max: 0.5 },
+      duration: defaultDuration,
+      asPercent: true,
     },
   },
   {
+    // ChaosDashCurse
     name: "Hobbled",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, your Dash is slower and uses ${value} mana (if you have it)`,
+      `For the next ${duration} Encounters, your Dash is slower and uses ${value} mana (if you have it).`,
     matcher: /hobbled/i,
     values: {
-      [COMMON]: { value: 5, duration: 5 },
+      value: { min: 3, max: 6 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosDeathWeaponCurse
     name: "Caustic",
     type: "curse",
-    info: (value, duration) =>
-      `For the next ${duration} Encounters, slain foes toss and Inferno Bomb at you`,
+    info: (_, duration) =>
+      `For the next ${duration} Encounters, slain foes toss and Inferno Bomb at you.`,
     matcher: /caustic/i,
     values: {
-      [COMMON]: { value: "", duration: 4 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosExAttackCurse
     name: "Gagged",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, each time you use [omega] moves, get hit for ${value} damage`,
+      `For the next ${duration} Encounters, each time you use [omega] moves, get hit for ${value} damage.`,
     matcher: /gagged/i,
     values: {
-      [COMMON]: { value: 6, duration: 3 },
+      value: { min: 5, max: 8 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosHealthCurse
     name: "Atrophic",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, you have ${value} less max health`,
+      `For the next ${duration} Encounters, you have ${value} less max health.`,
     matcher: /atrophic/i,
     values: {
-      [COMMON]: { value: 26, duration: 5 },
+      value: { min: 20, max: 29 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosHiddenRoomRewardCurse
     name: "Enshrouded",
     type: "curse",
-    info: (value, duration) =>
-      `For the next ${duration} Encounters, your Location Reward previews are hidden`,
+    info: (_, duration) =>
+      `For the next ${duration} Encounters, your Location Reward previews are hidden.`,
     matcher: /enshrouded/i,
     values: {
-      [COMMON]: { value: "", duration: 5 },
+      duration: { min: 4, max: 6 },
+      asPercent: false,
     },
   },
   {
+    // ChaosManaFocusCurse
     name: "Fixated",
     type: "curse",
-    info: (value, duration) =>
-      `For the next ${duration} Encounters, whenever you use [mana] prime it`,
+    info: (_, duration) =>
+      `For the next ${duration} Encounters, whenever you use [mana] prime it.`,
     matcher: /fixated/i,
     values: {
-      [COMMON]: { value: "", duration: 4 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosMetaUpgradeCurse
+    // Special curse; guarantees a heroic blessing.
     name: "Barren",
     type: "curse",
-    info: (value, duration) =>
-      `For the next ${duration} Encounters, your arcana cards have no effect`,
+    info: (_, duration) =>
+      `For the next ${duration} Encounters, your arcana cards have no effect. [Paired Blessing is always Heroic.]`,
     matcher: /barren/i,
     values: {
-      [COMMON]: { value: "", duration: 9 },
+      duration: { min: 7, max: 11 },
+      asPercent: false,
     },
   },
   {
+    // ChaosNoMoneyCurse
     name: "Pauper's",
     type: "curse",
-    info: (value, duration) =>
-      `For the next ${duration} Encounters, you cannot earn money`,
+    info: (_, duration) =>
+      `For the next ${duration} Encounters, you cannot earn money.`,
     matcher: /pauper'?s/i,
     values: {
-      [COMMON]: { value: "", duration: 3 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosPrimaryAttackCurse
     name: "Maimed",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, each time you use Attacks, get hit for ${value} damage`,
+      `For the next ${duration} Encounters, each time you use Attacks, get hit for ${value} damage.`,
     matcher: /maimed/i,
     values: {
-      [COMMON]: { value: 5, duration: 5 },
+      value: { min: 3, max: 6 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosRestrictBoonCurse
     name: "Rejected",
     type: "curse",
-    info: (value, duration) =>
-      `Your next ${duration} Boons you find will have ${value} fewer blessings to choose from`,
+    info: (_, duration) =>
+      `Your next ${duration} Boons you find will have 1 fewer blessing to choose from.`,
     matcher: /rejected/i,
     values: {
-      [COMMON]: { value: 1, duration: 2 },
+      duration: { min: 2, max: 4 },
+      asPercent: false,
     },
   },
   {
+    // ChaosSecondaryAttackCurse
     name: "Flayed",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, each time you use Specials, get hit for ${value} damage`,
+      `For the next ${duration} Encounters, each time you use Specials, get hit for ${value} damage.`,
     matcher: /flayed/i,
     values: {
-      [COMMON]: { value: 4, duration: 3 },
+      value: { min: 3, max: 6 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosSpeedCurse
     name: "Slothful",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, you move and Sprint ${value} slower`,
+      `For the next ${duration} Encounters, you move and Sprint ${value} slower.`,
     matcher: /slothful/i,
     values: {
-      [COMMON]: { value: "44%", duration: 4 },
+      value: { min: 0.4, max: 0.6 },
+      duration: defaultDuration,
+      asPercent: true,
     },
   },
   {
+    // ChaosStunCurse
     name: "Paralyzing",
     type: "curse",
     info: (value, duration) =>
-      `For the next ${duration} Encounters, whenever you take damage, you are stunned for ${value} seconds`,
-    matcher: /Paralyzing/i,
+      `For the next ${duration} Encounters, whenever you take damage, you are stunned for ${value} seconds.`,
+    matcher: /paralyzing/i,
     values: {
-      [COMMON]: { value: 1.2, duration: 3 },
+      value: { min: 0.5, max: 1.4 },
+      duration: defaultDuration,
+      asPercent: false,
     },
   },
   {
+    // ChaosTimeCurse
     name: "Doomed",
     type: "curse",
     info: (value, duration) =>
-      `You have ${value} seconds to clear ${duration} Encounters, or get hit for 500 damage`,
-    matcher: /Doomed/i,
+      `You have 120 seconds to clear ${duration} Encounters, or get hit for 500 damage.`,
+    matcher: /doomed/i,
     values: {
-      [COMMON]: { value: 120, duration: 3 },
+      duration: { min: 2, max: 3 },
+      asPercent: true,
     },
   },
 ];
 
 export const blessings: ChaosBlessing[] = [
   {
+    // ChaosCastBlessing
     name: "Chasm",
     type: "blessing",
-    info: (value) => `Afterward, your Casts deal ${value} damage`,
-    matcher: /Chasm/i,
+    info: (value) => `Afterward, your Casts deal ${value} more damage.`,
+    matcher: /chasm/i,
     values: {
-      [COMMON]: { value: "39%" },
-    },
+      baseMin: 0.2,
+      baseMax: 0.5,
+      rarityMultipliers: defaultRarityMultipliers,
+      asPercent: true,
+    }
   },
   {
+    // ChaosDoorHealBlessing
     name: "Blood",
     type: "blessing",
     info: (value) =>
-      `Afterward, whenever you exit a Location, restore ${value} health`,
-    matcher: /Blood/i,
+      `Afterward, whenever you exit a Location, restore ${value} health.`,
+    matcher: /blood/i,
     values: {
-      [COMMON]: { value: 3 },
+      baseMin: 3,
+      baseMax: 4,
+      rarityMultipliers: {
+        [COMMON]: 1,
+        [RARE]: 3,
+        [EPIC]: 5,
+        [HEROIC]: 7,
+      },
+      asPercent: false,
     },
   },
   {
+    // ChaosElementalBlessing
     name: "Creation",
     type: "blessing",
     info: (value) =>
-      `Afterward, gain ${value} [earth] [water] [air] [fire] [cosmic]`,
+      `Afterward, gain ${value} [earth] [water] [air] [fire] [cosmic].`,
     matcher: /creation/i,
     values: {
-      [COMMON]: { value: 1 },
+      baseMin: 1,
+      baseMax: 1,
+      rarityMultipliers: {
+        [COMMON]: 1,
+        [RARE]: 2,
+        [EPIC]: 3,
+        [HEROIC]: 4,
+      },
+      asPercent: false,
     },
   },
   {
+    // ChaosExSpeedBlessing
     name: "Revelation",
     type: "blessing",
     info: (value) =>
-      `Afterward, you Channel  your [omega] Moves ${value} faster`,
+      `Afterward, you Channel  your [omega] Moves ${value} faster.`,
     matcher: /revelation/i,
     values: {
-      [COMMON]: { value: "12%" },
+      baseMin: 0.10,
+      baseMax: 0.15,
+      rarityMultipliers: defaultRarityMultipliers,
+      asPercent: true,
     },
   },
   {
+    // ChaosHarvestBlessing
     name: "Discovery",
     type: "blessing",
     info: (value) =>
-      `Afterward, you have a ${value} chance to find +100% resources with your Gathering Tools`,
+      `Afterward, you have a ${value} chance to find +100% resources with your Gathering Tools.`,
     matcher: /discovery/i,
     values: {
-      [COMMON]: { value: "58%" },
+      baseMin: 0.4,
+      baseMax: 0.5,
+      rarityMultipliers: {
+        [COMMON]: 1.4,
+        [RARE]: 1.6,
+        [EPIC]: 1.8,
+        [HEROIC]: 2.0,
+      },
+      asPercent: true,
     },
   },
   {
+    // ChaosHealthBlessing
     name: "Soul",
     type: "blessing",
-    info: (value) => `Afterward, you get +${value} max health`,
+    info: (value) => `Afterward, you get +${value} max health.`,
     matcher: /soul/i,
     values: {
-      [COMMON]: { value: 29 },
+      baseMin: 26,
+      baseMax: 35,
+      rarityMultipliers: {
+        [COMMON]: 1,
+        [RARE]: 2,
+        [EPIC]: 3,
+        [HEROIC]: 4,
+      },
+      asPercent: false,
     },
   },
   {
+    // ChaosManaBlessing
     name: "Mind",
     type: "blessing",
-    info: (value) => `Afterward, you get +${value} max [mana]`,
+    info: (value) => `Afterward, you get +${value} max [mana].`,
     matcher: /mind/i,
     values: {
-      [COMMON]: { value: 37 },
+      baseMin: 30,
+      baseMax: 40,
+      rarityMultipliers: defaultRarityMultipliers,
+      asPercent: false,
     },
   },
   {
+    // ChaosManaCostBlessing
     name: "Talent",
     type: "blessing",
-    info: (value) => `Afterward, you use ${value} less mana`,
+    info: (value) => `Afterward, you use ${value} less [mana].`,
     matcher: /talent/i,
     values: {
-      [COMMON]: { value: "30%" },
+      baseMin: 0.2,
+      baseMax: 0.3,
+      rarityMultipliers: defaultRarityMultipliers,
+      asPercent: true,
     },
   },
   {
+    // ChaosManaOverTimeBlessing
     name: "Will",
     type: "blessing",
-    info: (value) => `Afterward, restore ${value} mana every 1 second`,
+    info: (value) => `Afterward, restore ${value} mana every 1 second.`,
     matcher: /will/i,
     values: {
-      [COMMON]: { value: 5 },
+      baseMin: 4,
+      baseMax: 6,
+      rarityMultipliers: {
+        [COMMON]: 1,
+        [RARE]: 2,
+        [EPIC]: 3,
+        [HEROIC]: 4,
+      },
+      asPercent: false,
     },
   },
   {
+    // ChaosMoneyBlessing
     name: "Affluence",
     type: "blessing",
-    info: (value) => `Afterward, any [gold] you find is worth ${value} more`,
-    matcher: /Affluence/i,
+    info: (value) => `Afterward, any [gold] you find is worth ${value} more.`,
+    matcher: /affluence/i,
     values: {
-      [COMMON]: { value: "55%" },
+      baseMin: 0.4,
+      baseMax: 0.6,
+      rarityMultipliers: {
+        [COMMON]: 1,
+        [RARE]: 2,
+        [EPIC]: 3,
+        [HEROIC]: 4,
+      },
+      asPercent: true,
     },
   },
   {
+    // ChaosRarityBlessing
     name: "Favor",
     type: "blessing",
     info: (value) =>
-      `Afterward, Boons have a ${value} chance to be Rare or better`,
+      `Afterward, Boons have a ${value} chance to be Rare or better.`,
     matcher: /favor/i,
     values: {
-      [COMMON]: { value: "41%" },
+      baseMin: 0.4,
+      baseMax: 0.5,
+      rarityMultipliers: {
+        [COMMON]: 1.0,
+        [RARE]: 1.34,
+        [EPIC]: 1.67,
+        [HEROIC]: 2.0,
+      },
+      asPercent: true,
     },
   },
   {
+    // ChaosSpecialBlessing
     name: "Flourish",
     type: "blessing",
-    info: (value) => `Afterward, your Specials deal ${value} more damage`,
-    matcher: /Flourish/i,
+    info: (value) => `Afterward, your Specials deal ${value} more damage.`,
+    matcher: /flourish/i,
     values: {
-      [COMMON]: { value: "32%" },
+      baseMin: 0.3,
+      baseMax: 0.6,
+      rarityMultipliers: defaultRarityMultipliers,
+      asPercent: true,
     },
   },
   {
+    // ChaosSpeedBlessing
     name: "Celerity",
     type: "blessing",
-    info: (value) => `Afterward, you move and Sprint ${value} faster`,
-    matcher: /Celerity/i,
+    info: (value) => `Afterward, you move and Sprint ${value} faster.`,
+    matcher: /celerity/i,
     values: {
-      [COMMON]: { value: "15%" },
+      baseMin: 0.15,
+      baseMax: 0.15,
+      rarityMultipliers: {
+        [COMMON]: 1.0,
+        [RARE]: 1.33,
+        [EPIC]: 1.67,
+        [HEROIC]: 2.0,
+      },
+      asPercent: true,
     },
   },
   {
+    // ChaosWeaponBlessing
     name: "Strike",
     type: "blessing",
-    info: (value) => `Afterward, your Attacks deal ${value} more damage`,
-    matcher: /Strike/i,
+    info: (value) => `Afterward, your Attacks deal ${value} more damage.`,
+    matcher: /strike/i,
     values: {
-      [COMMON]: { value: "23%" },
+      baseMin: 0.2,
+      baseMax: 0.5,
+      rarityMultipliers: defaultRarityMultipliers,
+      asPercent: true,
     },
   },
   {
+    // ChaosOmegaDamageBlessing
+    // Prereq: >=1 cosmic / aether in current run.
     name: "Chant",
     type: "blessing",
     info: (value) =>
-      `Afterward, your [omega] moves deal ${value} more damage per [cosmic] you have`,
-    matcher: /Chant/i,
+      `Afterward, your [omega] moves deal ${value} more damage per [cosmic] you have.`,
+    matcher: /chant/i,
     values: {
-      [COMMON]: { value: "30%" },
+      baseMin: 0.3,
+      baseMax: 0.3,
+      rarityMultipliers: {
+        [COMMON]: 1.0,
+        [RARE]: 1.2,
+        [EPIC]: 1.4,
+        [HEROIC]: 1.6,
+      },
+      asPercent: true,
     },
   },
   {
+    // ChaosLastStandBlessing
+    // Prereq: At least one Chaos blessing in the current run.
     name: "Defiance",
     type: "blessing",
     info: (value) =>
-      `Afterward, gain ${value} uses of Death Defiance this night`,
-    matcher: /Defiance/i,
+      `Afterward, gain ${value} uses of Death Defiance this night.`,
+    matcher: /defiance/i,
     values: {
-      [LEGENDARY]: { value: 1 },
+      baseMin: 1,
+      baseMax: 1,
+      rarityMultipliers: { [LEGENDARY]: 1 },
+      asPercent: false,
     },
   },
 ];

--- a/src/data/chaos.ts
+++ b/src/data/chaos.ts
@@ -3,20 +3,12 @@ import { COSMIC } from "./gods/elements";
 import { God, InfusionBoon } from "./gods/god";
 import { COMMON, RARE, EPIC, HEROIC, LEGENDARY } from "./gods/rarities";
 
-type Range = {
+export type Range = {
   min: number;
   max: number;
 };
 
-// WIP: type / interface ChaosTrait which guarantees name, type, matcher, info, and values?
-// values are ChaosBlessingValues | ChaosCurseValues? info takes one or two params?
-
 export type ChaosCurseValues = {
-  // WIP: How much utility do we get out of Range as a type here?
-  // It cleans up this definition, but it also adds another layer of object to
-  // unpack. Whatever we do, we should probably align how ChaosCurseValues
-  // and ChaosBlessingValues work. (This will also facilitate some shared
-  // formatter code.)
   value?: Range;
   duration: Range;
 
@@ -35,45 +27,37 @@ const defaultDuration: Range = {
 type ChaosCurse = {
   // Commented object name in game source code, where known
   name: string;
-  // WIP: Capture types in global constant, if they are used at all.
-  type: "curse";
   matcher: RegExp;
-  // WIP: Would it help to give the info() params different names?
   info: (value: string, duration: string) => string;
   values: ChaosCurseValues;
 };
 
+// Defining RarityMultipliers guarantees that an implementer defines
+// at least one rarity, but allows for multiple.
+type RarityMultipliers =
+  { [COMMON]: number; } |
+  { [RARE]: number; } |
+  { [EPIC]: number; } |
+  { [HEROIC]: number; } |
+  { [LEGENDARY]: number; };
 
-// WIP: Should rarityMultipliers mimic the BoonValues Partial in god.ts?
-// Almost all Chaos blessings have a range of values.
 type ChaosBlessingValues = {
-  // Should this just be a Range?
-  baseMin: number;
-  baseMax: number;
-  rarityMultipliers: {
-    [COMMON]?: number;
-    [RARE]?: number;
-    [EPIC]?: number;
-    [HEROIC]?: number;
-    [LEGENDARY]?: number;
-  };
-
+  base: Range;
+  rarityMultipliers: RarityMultipliers;
   // See ChaosCurseValues.asPercent
   asPercent: boolean;
 };
 
-const defaultRarityMultipliers = {
+const defaultRarityMultipliers: RarityMultipliers = {
   [COMMON]: 1.0,
   [RARE]: 1.5,
   [EPIC]: 2.0,
   [HEROIC]: 2.5,
 };
 
-// WIP: Should this be "boonish"?
 type ChaosBlessing = {
   // Commented object name in game source code, where known
   name: string;
-  type: "blessing";
   matcher: RegExp;
   info: (value: string) => string;
   values: ChaosBlessingValues;
@@ -109,7 +93,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosCastCurse
     name: "Addled",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, each time you use your Cast, get hit for ${value} damage.`,
     matcher: /addled/i,
@@ -122,7 +105,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosCommonCurse
     name: "Ordinary",
-    type: "curse",
     info: (_, duration) =>
       `The next ${duration} Boons you find are limited to common blessings.`,
     matcher: /ordinary/i,
@@ -134,7 +116,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosDamageCurse
     name: "Excruciating",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, you take ${value} increased damage.`,
     matcher: /excruciating/i,
@@ -147,7 +128,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosDashCurse
     name: "Hobbled",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, your Dash is slower and uses ${value} mana (if you have it).`,
     matcher: /hobbled/i,
@@ -160,7 +140,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosDeathWeaponCurse
     name: "Caustic",
-    type: "curse",
     info: (_, duration) =>
       `For the next ${duration} Encounters, slain foes toss and Inferno Bomb at you.`,
     matcher: /caustic/i,
@@ -172,7 +151,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosExAttackCurse
     name: "Gagged",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, each time you use [omega] moves, get hit for ${value} damage.`,
     matcher: /gagged/i,
@@ -185,7 +163,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosHealthCurse
     name: "Atrophic",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, you have ${value} less max health.`,
     matcher: /atrophic/i,
@@ -198,7 +175,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosHiddenRoomRewardCurse
     name: "Enshrouded",
-    type: "curse",
     info: (_, duration) =>
       `For the next ${duration} Encounters, your Location Reward previews are hidden.`,
     matcher: /enshrouded/i,
@@ -210,7 +186,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosManaFocusCurse
     name: "Fixated",
-    type: "curse",
     info: (_, duration) =>
       `For the next ${duration} Encounters, whenever you use [mana] prime it.`,
     matcher: /fixated/i,
@@ -223,7 +198,6 @@ export const curses: ChaosCurse[] = [
     // ChaosMetaUpgradeCurse
     // Special curse; guarantees a heroic blessing.
     name: "Barren",
-    type: "curse",
     info: (_, duration) =>
       `For the next ${duration} Encounters, your arcana cards have no effect. [Paired Blessing is always Heroic.]`,
     matcher: /barren/i,
@@ -235,7 +209,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosNoMoneyCurse
     name: "Pauper's",
-    type: "curse",
     info: (_, duration) =>
       `For the next ${duration} Encounters, you cannot earn money.`,
     matcher: /pauper'?s/i,
@@ -247,7 +220,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosPrimaryAttackCurse
     name: "Maimed",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, each time you use Attacks, get hit for ${value} damage.`,
     matcher: /maimed/i,
@@ -260,7 +232,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosRestrictBoonCurse
     name: "Rejected",
-    type: "curse",
     info: (_, duration) =>
       `Your next ${duration} Boons you find will have 1 fewer blessing to choose from.`,
     matcher: /rejected/i,
@@ -272,7 +243,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosSecondaryAttackCurse
     name: "Flayed",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, each time you use Specials, get hit for ${value} damage.`,
     matcher: /flayed/i,
@@ -285,7 +255,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosSpeedCurse
     name: "Slothful",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, you move and Sprint ${value} slower.`,
     matcher: /slothful/i,
@@ -298,7 +267,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosStunCurse
     name: "Paralyzing",
-    type: "curse",
     info: (value, duration) =>
       `For the next ${duration} Encounters, whenever you take damage, you are stunned for ${value} seconds.`,
     matcher: /paralyzing/i,
@@ -311,7 +279,6 @@ export const curses: ChaosCurse[] = [
   {
     // ChaosTimeCurse
     name: "Doomed",
-    type: "curse",
     info: (value, duration) =>
       `You have 120 seconds to clear ${duration} Encounters, or get hit for 500 damage.`,
     matcher: /doomed/i,
@@ -326,12 +293,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosCastBlessing
     name: "Chasm",
-    type: "blessing",
     info: (value) => `Afterward, your Casts deal ${value} more damage.`,
     matcher: /chasm/i,
     values: {
-      baseMin: 0.2,
-      baseMax: 0.5,
+      base: { min: 0.2, max: 0.5 },
       rarityMultipliers: defaultRarityMultipliers,
       asPercent: true,
     }
@@ -339,13 +304,11 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosDoorHealBlessing
     name: "Blood",
-    type: "blessing",
     info: (value) =>
       `Afterward, whenever you exit a Location, restore ${value} health.`,
     matcher: /blood/i,
     values: {
-      baseMin: 3,
-      baseMax: 4,
+      base: { min: 3, max: 4 },
       rarityMultipliers: {
         [COMMON]: 1,
         [RARE]: 3,
@@ -358,13 +321,11 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosElementalBlessing
     name: "Creation",
-    type: "blessing",
     info: (value) =>
       `Afterward, gain ${value} [earth] [water] [air] [fire] [cosmic].`,
     matcher: /creation/i,
     values: {
-      baseMin: 1,
-      baseMax: 1,
+      base: { min: 1, max: 1 },
       rarityMultipliers: {
         [COMMON]: 1,
         [RARE]: 2,
@@ -377,13 +338,11 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosExSpeedBlessing
     name: "Revelation",
-    type: "blessing",
     info: (value) =>
       `Afterward, you Channel  your [omega] Moves ${value} faster.`,
     matcher: /revelation/i,
     values: {
-      baseMin: 0.10,
-      baseMax: 0.15,
+      base: { min: 0.10, max: 0.15 },
       rarityMultipliers: defaultRarityMultipliers,
       asPercent: true,
     },
@@ -391,13 +350,11 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosHarvestBlessing
     name: "Discovery",
-    type: "blessing",
     info: (value) =>
       `Afterward, you have a ${value} chance to find +100% resources with your Gathering Tools.`,
     matcher: /discovery/i,
     values: {
-      baseMin: 0.4,
-      baseMax: 0.5,
+      base: { min: 0.4, max: 0.5 },
       rarityMultipliers: {
         [COMMON]: 1.4,
         [RARE]: 1.6,
@@ -410,12 +367,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosHealthBlessing
     name: "Soul",
-    type: "blessing",
     info: (value) => `Afterward, you get +${value} max health.`,
     matcher: /soul/i,
     values: {
-      baseMin: 26,
-      baseMax: 35,
+      base: { min: 26, max: 35 },
       rarityMultipliers: {
         [COMMON]: 1,
         [RARE]: 2,
@@ -428,12 +383,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosManaBlessing
     name: "Mind",
-    type: "blessing",
     info: (value) => `Afterward, you get +${value} max [mana].`,
     matcher: /mind/i,
     values: {
-      baseMin: 30,
-      baseMax: 40,
+      base: { min: 30, max: 40 },
       rarityMultipliers: defaultRarityMultipliers,
       asPercent: false,
     },
@@ -441,12 +394,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosManaCostBlessing
     name: "Talent",
-    type: "blessing",
     info: (value) => `Afterward, you use ${value} less [mana].`,
     matcher: /talent/i,
     values: {
-      baseMin: 0.2,
-      baseMax: 0.3,
+      base: { min: 0.2, max: 0.3 },
       rarityMultipliers: defaultRarityMultipliers,
       asPercent: true,
     },
@@ -454,12 +405,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosManaOverTimeBlessing
     name: "Will",
-    type: "blessing",
     info: (value) => `Afterward, restore ${value} mana every 1 second.`,
     matcher: /will/i,
     values: {
-      baseMin: 4,
-      baseMax: 6,
+      base: { min: 4, max: 6 },
       rarityMultipliers: {
         [COMMON]: 1,
         [RARE]: 2,
@@ -472,12 +421,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosMoneyBlessing
     name: "Affluence",
-    type: "blessing",
     info: (value) => `Afterward, any [gold] you find is worth ${value} more.`,
     matcher: /affluence/i,
     values: {
-      baseMin: 0.4,
-      baseMax: 0.6,
+      base: { min: 0.4, max: 0.6 },
       rarityMultipliers: {
         [COMMON]: 1,
         [RARE]: 2,
@@ -490,13 +437,11 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosRarityBlessing
     name: "Favor",
-    type: "blessing",
     info: (value) =>
       `Afterward, Boons have a ${value} chance to be Rare or better.`,
     matcher: /favor/i,
     values: {
-      baseMin: 0.4,
-      baseMax: 0.5,
+      base: { min: 0.4, max: 0.5 },
       rarityMultipliers: {
         [COMMON]: 1.0,
         [RARE]: 1.34,
@@ -509,12 +454,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosSpecialBlessing
     name: "Flourish",
-    type: "blessing",
     info: (value) => `Afterward, your Specials deal ${value} more damage.`,
     matcher: /flourish/i,
     values: {
-      baseMin: 0.3,
-      baseMax: 0.6,
+      base: { min: 0.3, max: 0.6 },
       rarityMultipliers: defaultRarityMultipliers,
       asPercent: true,
     },
@@ -522,12 +465,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosSpeedBlessing
     name: "Celerity",
-    type: "blessing",
     info: (value) => `Afterward, you move and Sprint ${value} faster.`,
     matcher: /celerity/i,
     values: {
-      baseMin: 0.15,
-      baseMax: 0.15,
+      base: { min: 0.15, max: 0.15 },
       rarityMultipliers: {
         [COMMON]: 1.0,
         [RARE]: 1.33,
@@ -540,12 +481,10 @@ export const blessings: ChaosBlessing[] = [
   {
     // ChaosWeaponBlessing
     name: "Strike",
-    type: "blessing",
     info: (value) => `Afterward, your Attacks deal ${value} more damage.`,
     matcher: /strike/i,
     values: {
-      baseMin: 0.2,
-      baseMax: 0.5,
+      base: { min: 0.2, max: 0.5 },
       rarityMultipliers: defaultRarityMultipliers,
       asPercent: true,
     },
@@ -554,13 +493,11 @@ export const blessings: ChaosBlessing[] = [
     // ChaosOmegaDamageBlessing
     // Prereq: >=1 cosmic / aether in current run.
     name: "Chant",
-    type: "blessing",
     info: (value) =>
       `Afterward, your [omega] moves deal ${value} more damage per [cosmic] you have.`,
     matcher: /chant/i,
     values: {
-      baseMin: 0.3,
-      baseMax: 0.3,
+      base: { min: 0.3, max: 0.3 },
       rarityMultipliers: {
         [COMMON]: 1.0,
         [RARE]: 1.2,
@@ -574,13 +511,11 @@ export const blessings: ChaosBlessing[] = [
     // ChaosLastStandBlessing
     // Prereq: At least one Chaos blessing in the current run.
     name: "Defiance",
-    type: "blessing",
     info: (value) =>
       `Afterward, gain ${value} uses of Death Defiance this night.`,
     matcher: /defiance/i,
     values: {
-      baseMin: 1,
-      baseMax: 1,
+      base: { min: 1, max: 1 },
       rarityMultipliers: { [LEGENDARY]: 1 },
       asPercent: false,
     },

--- a/src/data/gods/all.ts
+++ b/src/data/gods/all.ts
@@ -8,6 +8,7 @@ import { hestia } from "./hestia";
 import { hephaestus } from "./hephaestus";
 import { apollo } from "./apollo";
 import { hera } from "./hera";
+import { chaos } from "../chaos";
 
 const gods = [
   zeus,
@@ -20,6 +21,7 @@ const gods = [
   hestia,
   hephaestus,
   hera,
+  chaos,
 ];
 
 export {
@@ -33,5 +35,6 @@ export {
   hestia,
   hephaestus,
   hera,
+  chaos,
   gods,
 };


### PR DESCRIPTION
Structures and adds all current Chaos data. Implements a new command to query that data for Chaos combos in the form of `!curse blessing`. Elevates Chaos as a "God" to make Chant, the Chaos infusion, queriable in the other ways one can query an infusion. Adds testing to cover all these cases.

Perhaps the most exciting aspect of this update is that all the Chaos data was built and confirmed with the source code open in a separate tab. (This is how I determined that all durations are a range, alongside most of the values, and how I found the multipliers to use for each Blessing rarity). I'm hopeful that this implementation sets the groundwork to do something similar for Boons and, eventually, to write a script which can quickly scrape updates / changes to the game source and help us update the code accordingly.

While the rangeString() function is defined locally in the ChaosCommand handler right now, I'm also hoping that I can airlift some of the logic to a shared helper for some of the boon formatting. Work for another refactor!