### PR TITLE
Refactors Duos

### DIFF
--- a/features/abilityCategories.feature
+++ b/features/abilityCategories.feature
@@ -21,15 +21,15 @@ Feature: Users can ask about God's ability by type
         Then the bot responds with <EXPECTED_COUNT> abilities
         Examples:
             | MULTI_ABILITY_CATEGORY | EXPECTED_COUNT |
-            | duos                   | 6              |
-            | other                  | 9              |
+            | duos                   | 8              |
+            | other                  | 8              |
 
 
     Scenario: A user should get a detailed explanation if requesting a category with a single entry
-        When the user says to the bot {!zeus <SINGEL_ENTRY_CATEGORY>}
+        When the user says to the bot {!zeus <SINGLE_ENTRY_CATEGORY>}
         Then the bot responds with {<BOON_NAME>}
         Examples:
-            | SINGEL_ENTRY_CATEGORY | BOON_NAME       |
+            | SINGLE_ENTRY_CATEGORY | BOON_NAME       |
             | attack                | Heaven Strike   |
             | special               | Heaven Flourish |
             | cast                  | Storm Ring      |

--- a/features/boons.feature
+++ b/features/boons.feature
@@ -25,6 +25,17 @@ Feature: A user can request information about a specific boon
         And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
         And the bot responds with {and (one of [Rapture Ring][Passion Dash][Glamour Gain])}
 
+    Scenario: A user asks about a duo boon
+        When the user says to the bot {!burning desire}
+        Then the bot responds with {Burning Desire (Aphrodite + Hestia) [Cosmic]}
+        And then the bot responds with {Up to +12 Lone Shades appear in Locations. Sprint into them to launch a fiery blast for (d:160) damage}
+
+    Scenario: A user asks for a duo boon's prereqs
+        When the user says to the bot {!burning desire reqs}
+        Then the bot responds with {Requirements for Burning Desire (Aphrodite + Hestia)}
+        And the bot responds with {(one of [Rapture Ring][Passion Dash][Glamour Gain])}
+        And the bot responds with {(one of [Smolder Ring][Soot Sprint][Hearth Gain])}
+
     Scenario: A user asks for prereqs for a boon that has none
         When the user says to the bot {!flutter strike reqs}
         Then the bot responds with {No known requirements}
@@ -40,11 +51,6 @@ Feature: A user can request information about a specific boon
         Then the bot responds with {Requirements for Ecstatic Obsession (Aphrodite)}
         And the bot responds with {(one of [Broken Resolve][Sweet Surrender])}
         And the bot responds with {and (one of [Rapture Ring][Passion Dash][Glamour Gain])}
-
-    Scenario: A user asks for a duo that has the same name for two gods
-        Given PENDING
-        When the user says to the bot {!golden rule}
-        Then the bot responds with {this is broken; chooses one of the two gods}
 
     Scenario: A user asks for Chaos' infusion
         When the user says to the bot {!chant}

--- a/features/gods.feature
+++ b/features/gods.feature
@@ -10,7 +10,7 @@ Feature: Requests about gods and their boons
 
     Scenario: A user can request information about a god's attack
         When the user says to the bot {!poseidon attack}
-        Then the bot responds with {Wave Strike (Poseidon)}
+        Then the bot responds with {Wave Strike (Poseidon) [Water]}
         And the bot responds with {Your Attacks hit foes with a splash that knocks foes away and deals}
         And the bot responds with {c:15}
 
@@ -41,10 +41,9 @@ Feature: Requests about gods and their boons
 
     Scenario: A user can request information about a god's duos
         When the user says to the bot {!poseidon duos}
-        Then the bot responds with {[island getaway] [natural selection] [killer current] [seismic hammer] [golden rule] [beach ball] [scalding vapor]}
+        Then the bot responds with {[island getaway] [beach ball] [natural selection] [seismic hammer] [golden rule] [scalding vapor] [killer current]}
 
     Scenario: A user requests an attack for a god who has none
-        Given PENDING
         When the user says to the bot {!hermes attack}
         Then the bot responds with {Hermes has no [attack] boon}
 

--- a/src/commands/boon.ts
+++ b/src/commands/boon.ts
@@ -3,6 +3,7 @@ import { Command } from "./command";
 import { gods } from "../data/gods/all";
 import { abilityFormatter, prereqsFormatter } from "./utils/formatters";
 import { Boon } from "../data/gods/god";
+import { duos } from "../data/gods/duos";
 
 type BoonRecord = {
   god: string;
@@ -21,6 +22,13 @@ const abilityMatchersMap: { [matcher: string]: BoonRecord} = gods
   ).reduce(
     (resultObj, current) => ({ ...resultObj, ...current })
   );
+
+// A little magic: the God1 + God2 string we make here slots right into
+// the formatter later.
+duos.forEach((duo) => {
+  abilityMatchersMap[duo.name.replace(" ", " *")] =
+    {god: duo.gods[0].name + " + " + duo.gods[1].name, boon: duo};
+});
 
 const abilityNameRegexes = Object.keys(abilityMatchersMap).join("|");
 const abilityCommand = RegExp(`^(${abilityNameRegexes})( req(?:uirement)?s)?$`, "i");

--- a/src/data/gods/abilityTypes.ts
+++ b/src/data/gods/abilityTypes.ts
@@ -7,6 +7,7 @@ export type StandardBoonType =
   | typeof OTHER;
 
 export type InfusionBoonType = typeof INFUSION;
+export type DuoBoonType = typeof DUO;
 
 const ATTACK = "Attack";
 const SPECIAL = "Special";
@@ -15,6 +16,7 @@ const DASH = "Dash";
 const GAIN = "Gain";
 const OTHER = "Other";
 const INFUSION = "Infusion";
+const DUO = "Duo";
 
-const abilities = [ATTACK, SPECIAL, CAST, DASH, GAIN, OTHER, INFUSION];
-export { ATTACK, CAST, DASH, GAIN, INFUSION, OTHER, SPECIAL, abilities };
+const abilities = [ ATTACK, SPECIAL, CAST, DASH, GAIN, OTHER, INFUSION, DUO, ];
+export { ATTACK, CAST, DASH, GAIN, INFUSION, OTHER, SPECIAL, DUO, abilities };

--- a/src/data/gods/aphrodite.ts
+++ b/src/data/gods/aphrodite.ts
@@ -7,21 +7,9 @@ import {
   OTHER,
   SPECIAL,
 } from "./abilityTypes";
-import { lucidGain, novaFlourish, novaStrike, solarRing } from "./apollo";
-import { plentifulForage, winterCoat } from "./demeter";
-import { AIR, COSMIC, WATER } from "./elements";
+import { AIR, WATER } from "./elements";
 import { Boon, God, InfusionBoon, listElements } from "./god";
-import { anvilRing, fixedGain, smithySprint } from "./hephaestus";
-import { nastyComeback, nexusSprint, swornFlourish, swornStrike } from "./hera";
-import { hearthGain, smolderRing, sootSprint } from "./hestia";
-import {
-  breakerSprint,
-  geyserRing,
-  waveFlourish,
-  waveStrike,
-} from "./poseidon";
-import { COMMON, DUO, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
-import { heavenFlourish, heavenStrike } from "./zeus";
+import { COMMON, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
 
 const info =
   "Aphrodite, Goddess of Love. Her powers weaken enemies causing them to do less damage";
@@ -163,7 +151,7 @@ export const lifeAffirmation: Boon = {
 };
 
 const secretCrush: Boon = {
-  name: "Secret Crash",
+  name: "Secret Crush",
   type: OTHER,
   element: AIR,
   info: (value) =>
@@ -195,36 +183,6 @@ const sweetSurrender: Boon = {
   prerequisites: [[raptureRing, passionDash, glamourGain]],
 };
 
-const burningDesire: Boon = {
-  name: "Burning Desire",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Up to +12 Lone Shades appear in Locations. Sprint into them to launch a fiery blast for ${value} damage`,
-  values: {
-    [DUO]: { 1: 160 },
-  },
-  prerequisites: [
-    [raptureRing, passionDash, glamourGain],
-    [smolderRing, sootSprint, hearthGain],
-  ],
-};
-
-const romanticSpark: Boon = {
-  name: "Romantic Spark",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `If you Sprint into [blitz]-afflicted foes, the effect actives immediately and is ${value} stronger`,
-  values: {
-    [DUO]: { 1: "200%" },
-  },
-  prerequisites: [
-    [heavenFlourish, heavenStrike],
-    [passionDash, raptureRing, flutterFlourish, flutterStrike],
-  ],
-};
-
 const ecstaticObsession: Boon = {
   name: "Ecstatic Obsession",
   type: OTHER,
@@ -241,97 +199,17 @@ const ecstaticObsession: Boon = {
   ],
 };
 
-const islandGetaway: Boon = {
-  name: "Island Getaway",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `You take ${value} less damage from nearby foes. Boons of Aphrodite treat all foes as nearby.`,
-  values: {
-    [DUO]: { 1: "15%" },
-  },
-  prerequisites: [
-    [waveStrike, waveFlourish, geyserRing, breakerSprint],
-    [flutterStrike, flutterFlourish],
-  ],
-};
-
-const softCaress: Boon = {
-  name: "Soft Caress",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `The first time you would take damage in each Encounter, turn ${value} of the hit into healing`,
-  values: {
-    [DUO]: { 1: "75%" },
-  },
-  prerequisites: [
-    [raptureRing, passionDash, glamourGain],
-    [anvilRing, smithySprint, fixedGain],
-  ],
-};
-
-const sunnyDisposition: Boon = {
-  name: "Sunny Disposition",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) => `Whenever you create Heartthrobs, create ${value} more`,
-  values: {
-    [DUO]: { 1: 2 },
-  },
-  prerequisites: [
-    [heartBreaker],
-    [novaStrike, novaFlourish, lucidGain, solarRing],
-  ],
-};
-
-const heartyAppetite: Boon = {
-  name: "Hearty Appetite",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) => `You deal ${value} more damage per 100 max health`,
-  values: {
-    [DUO]: { 1: "10%" },
-  },
-  prerequisites: [
-    [plentifulForage, winterCoat],
-    [shamelessAttitude, lifeAffirmation, healthyRebound],
-  ],
-};
-
-const soulMate: Boon = {
-  name: "Soul Mate",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Foes with [hitch] take ${value} more damage and are [weak], but only 2 can be afflicted at a time.`,
-  values: {
-    [DUO]: { 1: "20%" },
-  },
-  prerequisites: [
-    [swornStrike, swornFlourish, nexusSprint, nastyComeback],
-    [raptureRing, passionDash, glamourGain],
-  ],
-};
-
 const abilities = {
   attack,
   special,
   dash,
   cast,
   gain,
-  "secret crush": secretCrush,
-  "shameless attitude": shamelessAttitude,
+  secretCrush,
+  shamelessAttitude,
   heartBreaker,
   lifeAffirmation,
-  burningDesire,
   ecstaticObsession,
-  islandGetaway,
-  softCaress,
-  sunnyDisposition,
-  heartyAppetite,
-  soulMate,
-  romanticSpark,
   wispyWiles,
 };
 

--- a/src/data/gods/apollo.ts
+++ b/src/data/gods/apollo.ts
@@ -7,23 +7,9 @@ import {
   OTHER,
   SPECIAL,
 } from "./abilityTypes";
-import { heartBreaker } from "./aphrodite";
-import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
-import { AIR, COSMIC, FIRE } from "./elements";
+import { AIR, FIRE } from "./elements";
 import { Boon, God, InfusionBoon, listElements } from "./god";
-import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
-import { bornGain, engagementRing, nexusSprint } from "./hera";
-import {
-  burntOffering,
-  flameFlourish,
-  flameStrike,
-  flammableCoating,
-  hearthGain,
-  smolderRing,
-} from "./hestia";
-import { breakerSprint, fluidGain } from "./poseidon";
-import { COMMON, DUO, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
-import { heavenFlourish, heavenStrike, thunderSprint } from "./zeus";
+import { COMMON, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
 
 const info = "Apollo, God of Light and Sun";
 
@@ -228,128 +214,21 @@ const exceptionalTalent: Boon = {
   ],
 };
 
-const gloriousDisaster: Boon = {
-  name: "Glorious Disaster",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `You can Channel +30 [mana] into your [omega] Cast to repeatedly strike foes for ${value} bolt damage every 0.13 seconds`,
-  values: {
-    [LEGENDARY]: { 1: 50 },
-  },
-  prerequisites: [[solarRing], [heavenStrike, heavenFlourish, thunderSprint]],
-};
-
-const torrentialDownpour: Boon = {
-  name: "Torrential Downpour",
-  type: OTHER,
-  info: (value) =>
-    `Each time you use your [omega] Cast in an Encounter, it gets ${value} stronger but also uses +5 [mana]`,
-  values: {
-    [DUO]: { 1: "20%" },
-  },
-  prerequisites: [
-    [solarRing, blindingSprint, lucidGain],
-    [arcticRing, frigidSprint, tranquilGain],
-  ],
-};
-
-const stellarSlam: Boon = {
-  name: "Stellar Slam",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your blast effects from Hephaestus deal damage in a ${value} larger area`,
-  values: {
-    [DUO]: { 1: "50%" },
-  },
-  prerequisites: [
-    [novaStrike, novaFlourish, superNova],
-    [volcanicFlourish, volcanicStrike, smithySprint],
-  ],
-};
-
-const phoenixSkin: Boon = {
-  name: "Phoenix Skin",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Give up -100 max health. If you do not take or deal damage for 3 seconds, rapidly restore ${value} health/sec`,
-  values: {
-    [DUO]: {
-      1: 3,
-    },
-  },
-  prerequisites: [
-    [novaStrike, novaFlourish, lucidGain],
-    [flameStrike, flameFlourish, smolderRing],
-    [burntOffering, flammableCoating, hearthGain],
-  ],
-};
-
-const sunnyDisposition: Boon = {
-  name: "Sunny Disposition",
-  type: OTHER,
-  info: (value) => `Whenever you create Heartthrobs, create ${value} more`,
-  values: {
-    [DUO]: { 1: 2 },
-  },
-  prerequisites: [
-    [heartBreaker],
-    [novaStrike, novaFlourish, lucidGain, solarRing],
-  ],
-};
-
-const beachBall: Boon = {
-  name: "Beach Ball",
-  type: OTHER,
-  info: (value) =>
-    `Your Sprint creates a water sphere behind you. After you stop, it surges ahead and bursts for ${value} damage`,
-  values: {
-    [DUO]: { 1: 140 },
-  },
-  prerequisites: [
-    [blindingSprint, lucidGain],
-    [breakerSprint, fluidGain],
-  ],
-};
-
-const sunWorshiper: Boon = {
-  name: "Sun Worshiper",
-  type: OTHER,
-  info: (value) =>
-    `In each Encounter, the first foe you slay returns to fight for you dealing ${value} of its normal damage`,
-  values: {
-    [DUO]: { 1: "200%" },
-  },
-  prerequisites: [
-    [engagementRing, nexusSprint, bornGain],
-    [solarRing, blindingSprint, lucidGain],
-  ],
-};
-
 const abilities = {
   attack,
   special,
   dash,
   cast,
   gain,
-  "extra dose": extraDose,
-  "super nova": superNova,
-  "self healing": selfHealing,
-  "perfect image": perfectImage,
+  extraDose,
+  superNova,
+  selfHealing,
+  perfectImage,
   dazzlingDisplay,
   backBurner,
   criticalMiss,
-  stellarSlam,
   lightSmite,
-  phoenixSkin,
   exceptionalTalent,
-  gloriousDisaster,
-  torrentialDownpour,
-  sunnyDisposition,
-  beachBall,
-  sunWorshiper,
 };
 
 export const apollo: God = {

--- a/src/data/gods/demeter.ts
+++ b/src/data/gods/demeter.ts
@@ -1,24 +1,7 @@
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
-import {
-  healthyRebound,
-  lifeAffirmation,
-  shamelessAttitude,
-} from "./aphrodite";
-import { blindingSprint, lucidGain, solarRing } from "./apollo";
-import { COSMIC, EARTH, WATER } from "./elements";
+import { EARTH, WATER } from "./elements";
 import { Boon, God, InfusionBoon, listElements } from "./god";
-import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
-import { bornGain, engagementRing, nexusSprint } from "./hera";
-import { flameFlourish, flameStrike } from "./hestia";
-import {
-  breakerSprint,
-  doubleUp,
-  fluidGain,
-  oceansBounty,
-  sunkenTreasure,
-} from "./poseidon";
-import { COMMON, DUO, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
-import { heavenFlourish, heavenStrike } from "./zeus";
+import { COMMON, EPIC, HEROIC, LEGENDARY, RARE } from "./rarities";
 
 const info = "Demeter, Goddess of Seasons. Her abilities slows enemies.";
 
@@ -209,21 +192,6 @@ const localClimate: Boon = {
   },
 };
 
-const roomTemperature: Boon = {
-  name: "Room Temperature",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your blast effects from Hephaestus clear [freeze], so you [freeze] foes again right away.`,
-  values: {
-    [DUO]: { 1: 0 },
-  },
-  prerequisites: [
-    [volcanicFlourish, volcanicStrike, smithySprint],
-    [iceStrike, iceFlourish],
-  ],
-};
-
 export const coldStorage: Boon = {
   name: "Cold Storage",
   type: OTHER,
@@ -251,92 +219,6 @@ const winterHarvest: Boon = {
   ],
 };
 
-const torrentialDownpour: Boon = {
-  name: "Torrential Downpour",
-  type: OTHER,
-  info: (value) =>
-    `Each time you use your [omega] Cast in an Encounter, it gets ${value} stronger but also uses +5 [mana]`,
-  values: {
-    [DUO]: { 1: "20%" },
-  },
-  prerequisites: [
-    [solarRing, blindingSprint, lucidGain],
-    [arcticRing, frigidSprint, tranquilGain],
-  ],
-};
-
-const freezerBurn: Boon = {
-  name: "Freezer Burn",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Whenever you inflict [freeze], amplify any [scorch] effects already on the foe by ${value}`,
-  values: {
-    [DUO]: { 1: "100%" },
-  },
-  prerequisites: [
-    [iceStrike, iceFlourish],
-    [flameStrike, flameFlourish],
-  ],
-};
-
-const apocalypticStorm: Boon = {
-  name: "Apocalyptic Storm",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your [blitz] effects last ${value} seconds longer, and active against all [blitz]-afflicted foes at once`,
-  values: {
-    [DUO]: { 1: 8 },
-  },
-  prerequisites: [
-    [iceStrike, iceFlourish, arcticRing, frigidSprint],
-    [heavenStrike, heavenFlourish],
-  ],
-};
-
-const naturalSelection: Boon = {
-  name: "Natural Selection",
-  type: OTHER,
-  info: (value) =>
-    `Location Rewards exclude max health, max [mana], and gold. Boon are ${value} more likely to be Rare or better`,
-  values: {
-    [DUO]: { 1: "20%" },
-  },
-  prerequisites: [
-    [fluidGain, breakerSprint, oceansBounty, sunkenTreasure, doubleUp],
-    [tranquilGain, frigidSprint, winterCoat, coldStorage, rareCrop],
-  ],
-};
-
-const cherishedHeirloom: Boon = {
-  name: "Cherished Heirloom",
-  type: OTHER,
-  info: (value) =>
-    `Most other Keepsakes you equip are ${value} ranks strong this night (if possible)`,
-  values: {
-    [DUO]: { 1: 1 },
-  },
-  prerequisites: [
-    [nexusSprint, engagementRing, bornGain],
-    [arcticRing, frigidSprint, tranquilGain],
-  ],
-};
-
-const heartyAppetite: Boon = {
-  name: "Hearty Appetite",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) => `You deal ${value} more damage per 100 max health`,
-  values: {
-    [DUO]: { 1: "10%" },
-  },
-  prerequisites: [
-    [plentifulForage, winterCoat],
-    [shamelessAttitude, lifeAffirmation, healthyRebound],
-  ],
-};
-
 const abilities = {
   attack,
   special,
@@ -349,16 +231,9 @@ const abilities = {
   plentifulForage,
   coarseGrit,
   winterCoat,
-  roomTemperature,
   coldStorage,
   localClimate,
   winterHarvest,
-  torrentialDownpour,
-  freezerBurn,
-  apocalypticStorm,
-  naturalSelection,
-  cherishedHeirloom,
-  heartyAppetite,
 };
 
 export const demeter: God = {

--- a/src/data/gods/duos.ts
+++ b/src/data/gods/duos.ts
@@ -1,0 +1,541 @@
+import { DuoBoon } from "./god";
+import { DUO } from "./abilityTypes";
+import { COSMIC } from "./elements";
+// Gods
+import * as aphrodite from "./aphrodite";
+import * as apollo from "./apollo";
+import * as demeter from "./demeter";
+import * as hephaestus from "./hephaestus";
+import * as hera from "./hera";
+import * as hestia from "./hestia"
+import * as poseidon from "./poseidon";
+import * as zeus from "./zeus";
+
+const burningDesire: DuoBoon = {
+  name: "Burning Desire",
+  gods: [aphrodite.aphrodite, hestia.hestia],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Up to +12 Lone Shades appear in Locations. Sprint into them to launch a fiery blast for ${value} damage`,
+  values: {
+    [DUO]: { 1: 160 },
+  },
+  prerequisites: [
+    [aphrodite.raptureRing, aphrodite.passionDash, aphrodite.glamourGain],
+    [hestia.smolderRing, hestia.sootSprint, hestia.hearthGain],
+  ],
+};
+
+const romanticSpark: DuoBoon = {
+  name: "Romantic Spark",
+  gods: [aphrodite.aphrodite, zeus.zeus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `If you Sprint into [blitz]-afflicted foes, the effect actives immediately and is ${value} stronger`,
+  values: {
+    [DUO]: { 1: "200%" },
+  },
+  prerequisites: [
+    [zeus.heavenFlourish, zeus.heavenStrike],
+    [
+      aphrodite.passionDash,
+      aphrodite.raptureRing,
+      aphrodite.flutterFlourish,
+      aphrodite.flutterStrike
+    ],
+  ],
+};
+
+const islandGetaway: DuoBoon = {
+  name: "Island Getaway",
+  gods: [aphrodite.aphrodite, poseidon.poseidon],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `You take ${value} less damage from nearby foes. Boons of Aphrodite treat all foes as nearby.`,
+  values: {
+    [DUO]: { 1: "15%" },
+  },
+  prerequisites: [
+    [
+      poseidon.waveStrike,
+      poseidon.waveFlourish,
+      poseidon.geyserRing,
+      poseidon.breakerSprint
+    ],
+    [aphrodite.flutterStrike, aphrodite.flutterFlourish],
+  ],
+};
+
+const softCaress: DuoBoon = {
+  name: "Soft Caress",
+  gods: [aphrodite.aphrodite, hephaestus.hephaestus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `The first time you would take damage in each Encounter, turn ${value} of the hit into healing`,
+  values: {
+    [DUO]: { 1: "75%" },
+  },
+  prerequisites: [
+    [aphrodite.raptureRing, aphrodite.passionDash, aphrodite.glamourGain],
+    [hephaestus.anvilRing, hephaestus.smithySprint, hephaestus.fixedGain],
+  ],
+};
+
+const sunnyDisposition: DuoBoon = {
+  name: "Sunny Disposition",
+  gods: [aphrodite.aphrodite, apollo.apollo],
+  type: DUO,
+  element: COSMIC,
+  info: (value) => `Whenever you create Heartthrobs, create ${value} more`,
+  values: {
+    [DUO]: { 1: 2 },
+  },
+  prerequisites: [
+    [aphrodite.heartBreaker],
+    [apollo.novaStrike, apollo.novaFlourish, apollo.lucidGain, apollo.solarRing],
+  ],
+};
+
+const heartyAppetite: DuoBoon = {
+  name: "Hearty Appetite",
+  gods: [aphrodite.aphrodite, demeter.demeter],
+  type: DUO,
+  element: COSMIC,
+  info: (value) => `You deal ${value} more damage per 100 max health`,
+  values: {
+    [DUO]: { 1: "10%" },
+  },
+  prerequisites: [
+    [demeter.plentifulForage, demeter.winterCoat],
+    [aphrodite.shamelessAttitude, aphrodite.lifeAffirmation, aphrodite.healthyRebound],
+  ],
+};
+
+const soulMate: DuoBoon = {
+  name: "Soul Mate",
+  gods: [aphrodite.aphrodite, hera.hera],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Foes with [hitch] take ${value} more damage and are [weak], but only 2 can be afflicted at a time.`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [hera.swornStrike, hera.swornFlourish, hera.nexusSprint, hera.nastyComeback],
+    [aphrodite.raptureRing, aphrodite.passionDash, aphrodite.glamourGain],
+  ],
+};
+
+const torrentialDownpour: DuoBoon = {
+  name: "Torrential Downpour",
+  gods: [apollo.apollo, demeter.demeter],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Each time you use your [omega] Cast in an Encounter, it gets ${value} stronger but also uses +5 [mana]`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [apollo.solarRing, apollo.blindingSprint, apollo.lucidGain],
+    [demeter.arcticRing, demeter.frigidSprint, demeter.tranquilGain],
+  ],
+};
+
+const stellarSlam: DuoBoon = {
+  name: "Stellar Slam",
+  gods: [apollo.apollo, hephaestus.hephaestus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Your blast effects from Hephaestus deal damage in a ${value} larger area`,
+  values: {
+    [DUO]: { 1: "50%" },
+  },
+  prerequisites: [
+    [apollo.novaStrike, apollo.novaFlourish, apollo.superNova],
+    [hephaestus.volcanicFlourish, hephaestus.volcanicStrike, hephaestus.smithySprint],
+  ],
+};
+
+const phoenixSkin: DuoBoon = {
+  name: "Phoenix Skin",
+  gods: [apollo.apollo, hestia.hestia],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Give up -100 max health. If you do not take or deal damage for 3 seconds, rapidly restore ${value} health/sec`,
+  values: {
+    [DUO]: {
+      1: 3,
+    },
+  },
+  prerequisites: [
+    [apollo.novaStrike, apollo.novaFlourish, apollo.lucidGain],
+    [hestia.flameStrike, hestia.flameFlourish, hestia.smolderRing],
+    [hestia.burntOffering, hestia.flammableCoating, hestia.hearthGain],
+  ],
+};
+
+const beachBall: DuoBoon = {
+  name: "Beach Ball",
+  gods: [apollo.apollo, poseidon.poseidon],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Your Sprint creates a water sphere behind you. After you stop, it surges ahead and bursts for ${value} damage`,
+  values: {
+    [DUO]: { 1: 140 },
+  },
+  prerequisites: [
+    [apollo.blindingSprint, apollo.lucidGain],
+    [poseidon.breakerSprint, poseidon.fluidGain],
+  ],
+};
+
+const sunWorshiper: DuoBoon = {
+  name: "Sun Worshiper",
+  gods: [apollo.apollo, hera.hera],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `In each Encounter, the first foe you slay returns to fight for you dealing ${value} of its normal damage`,
+  values: {
+    [DUO]: { 1: "200%" },
+  },
+  prerequisites: [
+    [hera.engagementRing, hera.nexusSprint, hera.bornGain],
+    [apollo.solarRing, apollo.blindingSprint, apollo.lucidGain],
+  ],
+};
+
+const gloriousDisaster: DuoBoon = {
+  name: "Glorious Disaster",
+  gods: [apollo.apollo, zeus.zeus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `You can Channel +30 [mana] into your [omega] Cast to repeatedly strike foes for ${value} bolt damage every 0.13 seconds`,
+  values: {
+    [DUO]: { 1: 50 },
+  },
+  prerequisites: [
+    [apollo.solarRing],
+    [zeus.heavenStrike, zeus.heavenFlourish, zeus.thunderSprint]
+  ],
+};
+
+const roomTemperature: DuoBoon = {
+  name: "Room Temperature",
+  gods: [demeter.demeter, hephaestus.hephaestus],
+  type: DUO,
+  element: COSMIC,
+  info: (_) =>
+    `Your blast effects from Hephaestus clear [freeze], so you [freeze] foes again right away.`,
+  values: {
+    [DUO]: { 1: 0 },
+  },
+  prerequisites: [
+    [hephaestus.volcanicFlourish, hephaestus.volcanicStrike, hephaestus.smithySprint],
+    [demeter.iceStrike, demeter.iceFlourish],
+  ],
+};
+
+const freezerBurn: DuoBoon = {
+  name: "Freezer Burn",
+  gods: [demeter.demeter, hestia.hestia],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Whenever you inflict [freeze], amplify any [scorch] effects already on the foe by ${value}`,
+  values: {
+    [DUO]: { 1: "100%" },
+  },
+  prerequisites: [
+    [demeter.iceStrike, demeter.iceFlourish],
+    [hestia.flameStrike, hestia.flameFlourish],
+  ],
+};
+
+const apocalypticStorm: DuoBoon = {
+  name: "Apocalyptic Storm",
+  gods: [demeter.demeter, zeus.zeus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Your [blitz] effects last ${value} seconds longer, and active against all [blitz]-afflicted foes at once`,
+  values: {
+    [DUO]: { 1: 8 },
+  },
+  prerequisites: [
+    [demeter.iceStrike, demeter.iceFlourish, demeter.arcticRing, demeter.frigidSprint],
+    [zeus.heavenStrike, zeus.heavenFlourish],
+  ],
+};
+
+const naturalSelection: DuoBoon = {
+  name: "Natural Selection",
+  gods: [demeter.demeter, poseidon.poseidon],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Location Rewards exclude max health, max [mana], and gold. Boon are ${value} more likely to be Rare or better`,
+  values: {
+    [DUO]: { 1: "20%" },
+  },
+  prerequisites: [
+    [poseidon.fluidGain, poseidon.breakerSprint, poseidon.oceansBounty, poseidon.sunkenTreasure, poseidon.doubleUp],
+    [demeter.tranquilGain, demeter.frigidSprint, demeter.winterCoat, demeter.coldStorage, demeter.rareCrop],
+  ],
+};
+
+const cherishedHeirloom: DuoBoon = {
+  name: "Cherished Heirloom",
+  gods: [demeter.demeter, hera.hera],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Most other Keepsakes you equip are ${value} ranks strong this night (if possible)`,
+  values: {
+    [DUO]: { 1: 1 },
+  },
+  prerequisites: [
+    [hera.nexusSprint, hera.engagementRing, hera.bornGain],
+    [demeter.arcticRing, demeter.frigidSprint, demeter.tranquilGain],
+  ],
+};
+
+const chainReaction: DuoBoon = {
+  name: "Chain Reaction",
+  gods: [hephaestus.hephaestus, hestia.hestia],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `If you use your blast effects from Hephaestus just within ${value} seconds of them recharging, they fire 2 times`,
+  values: {
+    [DUO]: { 1: 0.85 },
+  },
+  prerequisites: [
+    [hephaestus.volcanicFlourish, hephaestus.volcanicStrike],
+    [hestia.flameStrike, hestia.flameFlourish, hestia.smolderRing],
+  ],
+};
+
+const spitefulStrength: DuoBoon = {
+  name: "Spiteful Strength",
+  gods: [hephaestus.hephaestus, hera.hera],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Your Attacks and Specials deal ${value} more damage while not empowered by Boons`,
+  values: {
+    [DUO]: "200%",
+  },
+  prerequisites: [
+    [hera.braveFace, hera.nastyComeback, hera.keenIntuition, hera.bornGain],
+    [
+      hephaestus.trustyShield,
+      hephaestus.mintCondition,
+      hephaestus.heavyMetal,
+      hephaestus.toughTrade,
+      hephaestus.uncannyFortitude,
+      hephaestus.fixedGain,
+    ],
+  ],
+};
+
+const seismicHammer: DuoBoon = {
+  name: "Seismic Hammer",
+  gods: [hephaestus.hephaestus, poseidon.poseidon],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Your [omega] cast occasionally creates a blast that deals 500 damage in the area. Recharges after ${value} seconds`,
+  values: {
+    [DUO]: { 1: 15 },
+  },
+  prerequisites: [
+    [poseidon.geyserRing],
+    [hephaestus.volcanicStrike, hephaestus.volcanicFlourish, hephaestus.smithySprint],
+  ],
+};
+
+const masterConductor: DuoBoon = {
+  name: "Master Conductor",
+  gods: [hephaestus.hephaestus, zeus.zeus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Your chain-lightning deals ${value} more damage per bounce and can bounce to you`,
+  values: {
+    [DUO]: { 1: "15%" },
+  },
+  prerequisites: [
+    [zeus.staticShock],
+    [hephaestus.fixedGain, hephaestus.trustyShield, hephaestus.heavyMetal, hephaestus.mintCondition, hephaestus.toughTrade],
+  ],
+};
+
+const funeralPyre: DuoBoon = {
+  name: "Funeral Pyre",
+  gods: [hera.hera, hestia.hestia],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `While you Channel your [omega] moves, repeatedly inflict ${value} [scorch] on nearby foes`,
+  values: {
+    [DUO]: { 1: 90 },
+  },
+  prerequisites: [
+    [hera.swornStrike, hera.swornFlourish, hera.engagementRing, hera.bornGain],
+    [hestia.flameStrike, hestia.flameFlourish, hestia.smolderRing, hestia.hearthGain],
+  ],
+};
+
+const goldenRule: DuoBoon = {
+  name: "Golden Rule",
+  gods: [hera.hera, poseidon.poseidon],
+  type: DUO,
+  element: COSMIC,
+  info: (value) => `You deal ${value} more damage per 100 gold you have`,
+  values: {
+    [DUO]: "5%",
+  },
+  prerequisites: [
+    [hera.engagementRing, hera.nexusSprint, hera.bornGain],
+    [poseidon.geyserRing, poseidon.breakerSprint, poseidon.fluidGain],
+    [poseidon.oceansBounty, poseidon.doubleUp],
+  ],
+};
+
+const queensRansom: DuoBoon = {
+  name: "Queen's Ransom",
+  gods: [hera.hera, zeus.zeus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Give up all your Boons of Zeus. For each raise all of your Boons of Hera by ${value} levels`,
+  values: {
+    [DUO]: { 1: 3 },
+  },
+  prerequisites: [
+    [hera.swornStrike, hera.swornFlourish, hera.nexusSprint, hera.engagementRing, hera.bornGain],
+    [zeus.heavenStrike, zeus.heavenFlourish, zeus.stormRing, zeus.thunderSprint, zeus.ionicGain],
+  ],
+};
+
+const thermalDynamics: DuoBoon = {
+  name: "Thermal Dynamics",
+  gods: [hestia.hestia, zeus.zeus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Your [blitz] effects also inflict ${value} [scorch] whenever they deal damage`,
+  values: {
+    [DUO]: { 1: 80 },
+  },
+  prerequisites: [
+    [zeus.heavenStrike, zeus.heavenFlourish],
+    [hestia.flameFlourish, hestia.flameStrike],
+  ],
+};
+
+const scaldingVapor: DuoBoon = {
+  name: "Scalding Vapor",
+  gods: [hestia.hestia, poseidon.poseidon],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `If foes with [slip] are struck with fire from Hestia, they are engulfed in [steam] that deals ${value} damage every 0.2 seconds`,
+  values: {
+    [DUO]: { 1: 25 },
+  },
+  prerequisites: [
+    [poseidon.slipperySlope],
+    [
+      hestia.flameStrike,
+      hestia.flameFlourish,
+      hestia.smolderRing,
+      hestia.spontaneousCombustion,
+      burningDesire,
+      hestia.controlledBurn,
+      hestia.glowingCoal,
+    ],
+  ],
+};
+
+const killerCurrent: DuoBoon = {
+  name: "Killer Current",
+  gods: [poseidon.poseidon, zeus.zeus],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Your lightning deals ${value} bonus damage to [slip]-afflicted foes`,
+  values: {
+    [DUO]: { 1: "30%" },
+  },
+  prerequisites: [
+    [poseidon.slipperySlope],
+    [
+      zeus.heavenStrike,
+      zeus.heavenFlourish,
+      zeus.stormRing,
+      zeus.thunderSprint,
+      zeus.divineVengeance,
+      zeus.lightningLance,
+    ],
+  ],
+};
+
+const kingsRansom: DuoBoon = {
+  name: "King's Ransom",
+  gods: [zeus.zeus, hera.hera],
+  type: DUO,
+  element: COSMIC,
+  info: (value) =>
+    `Give up all your Boons of Hera. For each raise all of your Boons of Zeus by ${value} levels`,
+  values: {
+    [DUO]: { 1: 2 },
+  },
+  prerequisites: [
+    [hera.swornFlourish, hera.swornStrike, hera.engagementRing, hera.nexusSprint, hera.bornGain],
+    [zeus.heavenFlourish, zeus.heavenStrike, zeus.stormRing, zeus.thunderSprint, zeus.ionicGain],
+  ],
+};
+
+export const duos: DuoBoon[] = [
+  burningDesire,
+  romanticSpark,
+  islandGetaway,
+  softCaress,
+  sunnyDisposition,
+  heartyAppetite,
+  soulMate,
+  torrentialDownpour,
+  stellarSlam,
+  phoenixSkin,
+  beachBall,
+  sunWorshiper,
+  gloriousDisaster,
+  roomTemperature,
+  freezerBurn,
+  apocalypticStorm,
+  naturalSelection,
+  cherishedHeirloom,
+  chainReaction,
+  spitefulStrength,
+  seismicHammer,
+  masterConductor,
+  funeralPyre,
+  goldenRule,
+  queensRansom,
+  thermalDynamics,
+  scaldingVapor,
+  killerCurrent,
+  kingsRansom,
+];

--- a/src/data/gods/god.ts
+++ b/src/data/gods/god.ts
@@ -1,6 +1,6 @@
 import { toArray } from "lodash";
-import { StandardBoonType, InfusionBoonType, INFUSION } from "./abilityTypes";
-import { BoonElement } from "./elements";
+import { StandardBoonType, InfusionBoonType, INFUSION, DuoBoonType } from "./abilityTypes";
+import { BoonElement, COSMIC } from "./elements";
 import { BoonRarity } from "./rarities";
 import { notNullOrUndefined } from "../../utils/arrayUtils";
 
@@ -8,7 +8,7 @@ export type BoonValues = Partial<
   Record<BoonRarity, { [level: number]: string | number }>
 >;
 
-export type Boon = StandardBoon | InfusionBoon;
+export type Boon = StandardBoon | InfusionBoon | DuoBoon;
 
 type StandardBoon = {
   name: string;
@@ -16,7 +16,7 @@ type StandardBoon = {
   element?: BoonElement;
   info: (value: string) => string;
   values: BoonValues;
-  prerequisites?: Array<Array<Boon>>;
+  prerequisites?: Boon[][];
 };
 
 export const isInfusion =
@@ -24,8 +24,16 @@ export const isInfusion =
 
 export type InfusionBoon = Omit<StandardBoon, "type" | "element?" | "prerequisites?"> & {
   type: InfusionBoonType;
-  requiredElements: Array<BoonElement>;
+  requiredElements: BoonElement[];
 };
+
+// TODO(sneakyteak): DuoBoon values should always be [DUO] rarity.
+export type DuoBoon = Omit<StandardBoon, "type" | "element?" | "prerequisites?"> & {
+  gods: [God, God];
+  type: DuoBoonType;
+  element: typeof COSMIC;
+  prerequisites: Boon[][];
+}
 
 export type God = {
   name: string;

--- a/src/data/gods/hephaestus.ts
+++ b/src/data/gods/hephaestus.ts
@@ -1,14 +1,7 @@
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
-import { glamourGain, passionDash, raptureRing } from "./aphrodite";
-import { novaFlourish, novaStrike, superNova } from "./apollo";
-import { iceFlourish, iceStrike } from "./demeter";
-import { COSMIC, EARTH, FIRE } from "./elements";
+import { EARTH, FIRE } from "./elements";
 import { Boon, God, InfusionBoon, listElements } from "./god";
-import { bornGain, braveFace, keenIntuition, nastyComeback } from "./hera";
-import { flameFlourish, flameStrike, smolderRing } from "./hestia";
-import { geyserRing } from "./poseidon";
-import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
-import { staticShock } from "./zeus";
+import { COMMON, EPIC, LEGENDARY, RARE } from "./rarities";
 
 const info = "Hephaestus, God of the Forge";
 
@@ -173,36 +166,6 @@ const fineTuning: Boon = {
   },
 };
 
-const roomTemperature: Boon = {
-  name: "Room Temperature",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your blast effects from Hephaestus clear [freeze], so you [freeze] foes again right away.`,
-  values: {
-    [DUO]: { 1: 0 },
-  },
-  prerequisites: [
-    [volcanicFlourish, volcanicStrike, smithySprint],
-    [iceStrike, iceFlourish],
-  ],
-};
-
-const chainReaction: Boon = {
-  name: "Chain Reaction",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `If you use your blast effects from Hephaestus just within ${value} seconds of them recharging, they fire 2 times`,
-  values: {
-    [DUO]: { 1: 0.85 },
-  },
-  prerequisites: [
-    [volcanicFlourish, volcanicStrike],
-    [flameStrike, flameFlourish, smolderRing],
-  ],
-};
-
 const moltenTouch: Boon = {
   name: "Molten Touch",
   type: OTHER,
@@ -213,88 +176,6 @@ const moltenTouch: Boon = {
     [COMMON]: { 1: "20%" },
     [EPIC]: { 1: "40%", 4: "75%" },
   },
-};
-
-const spitefulStrength: Boon = {
-  name: "Spiteful Strength",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your Attacks and Specials deal ${value} more damage while not empowered by Boons`,
-  values: {
-    [DUO]: "200%",
-  },
-  prerequisites: [
-    [braveFace, nastyComeback, keenIntuition, bornGain],
-    [
-      trustyShield,
-      mintCondition,
-      heavyMetal,
-      toughTrade,
-      uncannyFortitude,
-      fixedGain,
-    ],
-  ],
-};
-
-const softCaress: Boon = {
-  name: "Soft Caress",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `The first time you would take damage in each Encounter, turn ${value} of the hit into healing`,
-  values: {
-    [DUO]: { 1: "75%" },
-  },
-  prerequisites: [
-    [raptureRing, passionDash, glamourGain],
-    [anvilRing, smithySprint, fixedGain],
-  ],
-};
-
-const stellarSlam: Boon = {
-  name: "Stellar Slam",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your blast effects from Hephaestus deal damage in a ${value} larger area`,
-  values: {
-    [DUO]: { 1: "50%" },
-  },
-  prerequisites: [
-    [novaStrike, novaFlourish, superNova],
-    [volcanicFlourish, volcanicStrike, smithySprint],
-  ],
-};
-
-const seismicHammer: Boon = {
-  name: "Seismic Hammer",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your [omega] cast occasionally creates a blast that deals 500 damage in the area. Recharges after ${value} seconds`,
-  values: {
-    [DUO]: { 1: 15 },
-  },
-  prerequisites: [
-    [geyserRing],
-    [volcanicStrike, volcanicFlourish, smithySprint],
-  ],
-};
-
-const masterConductor: Boon = {
-  name: "Master Conductor",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your chain-lightning deals ${value} more damage per bounce and can bounce to you`,
-  values: {
-    [DUO]: { 1: "15%" },
-  },
-  prerequisites: [
-    [staticShock],
-    [fixedGain, trustyShield, heavyMetal, mintCondition, toughTrade],
-  ],
 };
 
 const abilities = {
@@ -308,16 +189,9 @@ const abilities = {
   heavyMetal,
   mintCondition,
   uncannyFortitude,
-  roomTemperature,
-  chainReaction,
-  stellarSlam,
   moltenTouch,
-  spitefulStrength,
-  softCaress,
   martialArt,
   fineTuning,
-  seismicHammer,
-  masterConductor,
 };
 
 export const hephaestus: God = {

--- a/src/data/gods/hera.ts
+++ b/src/data/gods/hera.ts
@@ -1,38 +1,7 @@
 import { ATTACK, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
-import { glamourGain, passionDash, raptureRing } from "./aphrodite";
-import { blindingSprint, lucidGain, solarRing } from "./apollo";
-import { arcticRing, frigidSprint, tranquilGain } from "./demeter";
-import { COSMIC, EARTH } from "./elements";
+import { EARTH } from "./elements";
 import { Boon, God, InfusionBoon, listElements } from "./god";
-import {
-  fixedGain,
-  heavyMetal,
-  mintCondition,
-  toughTrade,
-  trustyShield,
-  uncannyFortitude,
-} from "./hephaestus";
-import {
-  special as flameFlourish,
-  attack as flameStrike,
-  hearthGain,
-  cast as smolderRing,
-} from "./hestia";
-import {
-  breakerSprint,
-  doubleUp,
-  fluidGain,
-  geyserRing,
-  oceansBounty,
-} from "./poseidon";
-import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
-import {
-  heavenFlourish,
-  heavenStrike,
-  ionicGain,
-  stormRing,
-  thunderSprint,
-} from "./zeus";
+import { COMMON, EPIC, LEGENDARY, RARE } from "./rarities";
 
 const info = "Hera, Queen of the Gods";
 
@@ -211,114 +180,6 @@ export const braveFace: Boon = {
   ],
 };
 
-const funeralPyre: Boon = {
-  name: "Funeral Pyre",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `While you Channel your [omega] moves, repeatedly inflict ${value} [scorch] on nearby foes`,
-  values: {
-    [DUO]: { 1: 90 },
-  },
-  prerequisites: [
-    [attack, special, cast, bornGain],
-    [flameStrike, flameFlourish, smolderRing, hearthGain],
-  ],
-};
-
-const spitefulStrength: Boon = {
-  name: "Spiteful Strength",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your Attacks and Specials deal ${value} more damage while not empowered by Boons`,
-  values: {
-    [DUO]: "200%",
-  },
-  prerequisites: [
-    [braveFace, nastyComeback, keenIntuition, bornGain],
-    [
-      trustyShield,
-      mintCondition,
-      heavyMetal,
-      toughTrade,
-      uncannyFortitude,
-      fixedGain,
-    ],
-  ],
-};
-
-const cherishedHeirloom: Boon = {
-  name: "Cherished Heirloom",
-  type: OTHER,
-  info: (value) =>
-    `Most other Keepsakes you equip are ${value} ranks strong this night (if possible)`,
-  values: {
-    [DUO]: { 1: 1 },
-  },
-  prerequisites: [
-    [dash, cast, bornGain],
-    [arcticRing, frigidSprint, tranquilGain],
-  ],
-};
-
-const soulMate: Boon = {
-  name: "Soul Mate",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Foes with [hitch] take ${value} more damage and are [weak], but only 2 can be afflicted at a time.`,
-  values: {
-    [DUO]: { 1: "20%" },
-  },
-  prerequisites: [
-    [attack, special, dash, nastyComeback],
-    [raptureRing, passionDash, glamourGain],
-  ],
-};
-
-const goldenRule: Boon = {
-  name: "Golden Rule",
-  type: OTHER,
-  info: (value) => `You deal ${value} more damage per 100 gold you have`,
-  values: {
-    [DUO]: "5%",
-  },
-  prerequisites: [
-    [cast, dash, bornGain],
-    [geyserRing, breakerSprint, fluidGain],
-    [oceansBounty, doubleUp],
-  ],
-};
-
-const sunWorshiper: Boon = {
-  name: "Sun Worshiper",
-  type: OTHER,
-  info: (value) =>
-    `In each Encounter, the first foe you slay returns to fight for you dealing ${value} of its normal damage`,
-  values: {
-    [DUO]: { 1: "200%" },
-  },
-  prerequisites: [
-    [cast, dash, bornGain],
-    [solarRing, blindingSprint, lucidGain],
-  ],
-};
-
-const queensRansom: Boon = {
-  name: "Queen's Ransom",
-  type: OTHER,
-  info: (value) =>
-    `Give up all your Boons of Zeus. For each raise all of your Boons of Hera by ${value} levels`,
-  values: {
-    [DUO]: { 1: 3 },
-  },
-  prerequisites: [
-    [attack, special, dash, cast, bornGain],
-    [heavenStrike, heavenFlourish, stormRing, thunderSprint, ionicGain],
-  ],
-};
-
 const abilities = {
   attack,
   special,
@@ -334,13 +195,6 @@ const abilities = {
   dyingWish,
   nastyComeback,
   braveFace,
-  funeralPyre,
-  spitefulStrength,
-  cherishedHeirloom,
-  soulMate,
-  goldenRule,
-  sunWorshiper,
-  queensRansom,
   properUpbringing,
 };
 

--- a/src/data/gods/hestia.ts
+++ b/src/data/gods/hestia.ts
@@ -1,14 +1,7 @@
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
-import { glamourGain, passionDash, raptureRing } from "./aphrodite";
-import { lucidGain, novaFlourish, novaStrike } from "./apollo";
-import { iceFlourish, iceStrike } from "./demeter";
-import { COSMIC, FIRE } from "./elements";
+import { FIRE } from "./elements";
 import { Boon, God, InfusionBoon, listElements } from "./god";
-import { volcanicFlourish, volcanicStrike } from "./hephaestus";
-import { bornGain, engagementRing, swornFlourish, swornStrike } from "./hera";
-import { slipperySlope } from "./poseidon";
-import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
-import { heavenFlourish, heavenStrike } from "./zeus";
+import { COMMON, EPIC, LEGENDARY, RARE } from "./rarities";
 
 const info = "Goddess of flame";
 
@@ -214,69 +207,6 @@ const fireExtinguisher: Boon = {
   ],
 };
 
-const chainReaction: Boon = {
-  name: "Chain Reaction",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `If you use your blast effects from Hephaestus just within ${value} seconds of them recharging, they fire 2 times`,
-  values: {
-    [DUO]: { 1: 0.85 },
-  },
-  prerequisites: [
-    [volcanicFlourish, volcanicStrike],
-    [flameStrike, flameFlourish, smolderRing],
-  ],
-};
-
-const phoenixSkin: Boon = {
-  name: "Phoenix Skin",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Give up -100 max health. If you do not take or deal damage for 3 seconds, rapidly restore ${value} health/sec`,
-  values: {
-    [DUO]: {
-      1: 3,
-    },
-  },
-  prerequisites: [
-    [novaStrike, novaFlourish, lucidGain],
-    [flameStrike, flameFlourish, smolderRing],
-    [burntOffering, flammableCoating, hearthGain],
-  ],
-};
-
-const freezerBurn: Boon = {
-  name: "Freezer Burn",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Whenever you inflict [freeze], amplify any [scorch] effects already on the foe by ${value}`,
-  values: {
-    [DUO]: { 1: "100%" },
-  },
-  prerequisites: [
-    [iceStrike, iceFlourish],
-    [flameStrike, flameFlourish],
-  ],
-};
-
-export const burningDesire: Boon = {
-  name: "Burning Desire",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Up to +12 Lone Shades appear in Locations. Sprint into them to launch a fiery blast for ${value} damage`,
-  values: {
-    [DUO]: { 1: 160 },
-  },
-  prerequisites: [
-    [raptureRing, passionDash, glamourGain],
-    [smolderRing, sootSprint, hearthGain],
-  ],
-};
-
 const pyroTechnique: Boon = {
   name: "Pyro Technique",
   type: OTHER,
@@ -294,58 +224,6 @@ const pyroTechnique: Boon = {
   ],
 };
 
-const funeralPyre: Boon = {
-  name: "Funeral Pyre",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `While you Channel your [omega] moves, repeatedly inflict ${value} [scorch] on nearby foes`,
-  values: {
-    [DUO]: { 1: 90 },
-  },
-  prerequisites: [
-    [swornStrike, swornFlourish, engagementRing, bornGain],
-    [flameStrike, flameFlourish, smolderRing, hearthGain],
-  ],
-};
-
-const thermalDynamics: Boon = {
-  name: "Thermal Dynamics",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your [blitz] effects also inflict ${value} [scorch] whenever they deal damage`,
-  values: {
-    [DUO]: { 1: 80 },
-  },
-  prerequisites: [
-    [heavenStrike, heavenFlourish],
-    [flameFlourish, flameStrike],
-  ],
-};
-
-const scaldingVapor: Boon = {
-  name: "Scalding Vapor",
-  type: OTHER,
-  info: (value) =>
-    `If foes with [slip] are struck with fire from Hestia, they are engulfed in [steam] that deals ${value} damage every 0.2 seconds`,
-  values: {
-    [DUO]: { 1: 25 },
-  },
-  prerequisites: [
-    [slipperySlope],
-    [
-      flameStrike,
-      flameFlourish,
-      smolderRing,
-      spontaneousCombustion,
-      burningDesire,
-      controlledBurn,
-      glowingCoal,
-    ],
-  ],
-};
-
 const abilities = {
   attack,
   special,
@@ -355,19 +233,12 @@ const abilities = {
   controlledBurn,
   burntOffering,
   naturalGas,
-  funeralPyre,
   slowCooker,
   glowingCoal,
   fireExtinguisher,
   flammableCoating,
-  chainReaction,
-  phoenixSkin,
-  burningDesire,
   pyroTechnique,
   spontaneousCombustion,
-  freezerBurn,
-  scaldingVapor,
-  thermalDynamics,
 };
 
 export const hestia: God = {

--- a/src/data/gods/poseidon.ts
+++ b/src/data/gods/poseidon.ts
@@ -1,41 +1,14 @@
 import { ATTACK, CAST, DASH, INFUSION, OTHER, SPECIAL } from "./abilityTypes";
-import { flutterFlourish, flutterStrike } from "./aphrodite";
-import { blindingSprint, lucidGain } from "./apollo";
-import {
-  coldStorage,
-  frigidSprint,
-  rareCrop,
-  tranquilGain,
-  winterCoat,
-} from "./demeter";
-import { COSMIC, WATER } from "./elements";
+import { WATER } from "./elements";
 import { Boon, God, InfusionBoon, listElements } from "./god";
-import { smithySprint, volcanicFlourish, volcanicStrike } from "./hephaestus";
-import { bornGain, nexusSprint, swornStrike } from "./hera";
-import {
-  burningDesire,
-  controlledBurn,
-  flameFlourish,
-  flameStrike,
-  glowingCoal,
-  smolderRing,
-  spontaneousCombustion,
-} from "./hestia";
-import { COMMON, DUO, EPIC, LEGENDARY, RARE } from "./rarities";
-import {
-  divineVengeance,
-  heavenFlourish,
-  heavenStrike,
-  lightningLance,
-  stormRing,
-  thunderSprint,
-} from "./zeus";
+import { COMMON, EPIC, LEGENDARY, RARE } from "./rarities";
 
 const info = "Poseidon, God of the Sea. His powers knock enemies away.";
 
 const attack: Boon = {
   name: "Wave Strike",
   type: ATTACK,
+  element: WATER,
   info: (value) =>
     `Your Attacks hit foes with a splash that knocks foes away and deals ${value} damage`,
   values: {
@@ -231,121 +204,6 @@ const kingTide: Boon = {
   prerequisites: [[waveStrike, waveFlourish], [slipperySlope], [crashingWave]],
 };
 
-const islandGetaway: Boon = {
-  name: "Island Getaway",
-  type: OTHER,
-  info: (value) =>
-    `You take ${value} less damage from nearby foes. Boons of Aphrodite treat all foes as nearby.`,
-  values: {
-    [DUO]: { 1: "15%" },
-  },
-  prerequisites: [
-    [waveStrike, waveFlourish, geyserRing, breakerSprint],
-    [flutterStrike, flutterFlourish],
-  ],
-};
-
-const naturalSelection: Boon = {
-  name: "Natural Selection",
-  type: OTHER,
-  info: (value) =>
-    `Location Rewards exclude max health, max [mana], and gold. Boon are ${value} more likely to be Rare or better`,
-  values: {
-    [DUO]: { 1: "20%" },
-  },
-  prerequisites: [
-    [fluidGain, breakerSprint, oceansBounty, sunkenTreasure, doubleUp],
-    [tranquilGain, frigidSprint, winterCoat, coldStorage, rareCrop],
-  ],
-};
-
-const killerCurrent: Boon = {
-  name: "Killer Current",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your lightning deals ${value} bonus damage to [slip]-afflicted foes`,
-  values: {
-    [DUO]: { 1: "30%" },
-  },
-  prerequisites: [
-    [slipperySlope],
-    [
-      heavenStrike,
-      heavenFlourish,
-      stormRing,
-      thunderSprint,
-      divineVengeance,
-      lightningLance,
-    ],
-  ],
-};
-
-const seismicHammer: Boon = {
-  name: "Seismic Hammer",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your [omega] cast occasionally creates a blast that deals 500 damage in the area. Recharges after ${value} seconds`,
-  values: {
-    [DUO]: { 1: 15 },
-  },
-  prerequisites: [
-    [geyserRing],
-    [volcanicStrike, volcanicFlourish, smithySprint],
-  ],
-};
-
-const goldenRule: Boon = {
-  name: "Golden Rule",
-  type: OTHER,
-  info: (value) => `You deal ${value} more damage per 100 gold you have`,
-  values: {
-    [DUO]: "5%",
-  },
-  prerequisites: [
-    [swornStrike, nexusSprint, bornGain],
-    [geyserRing, breakerSprint, fluidGain],
-    [oceansBounty, doubleUp],
-  ],
-};
-
-const beachBall: Boon = {
-  name: "Beach Ball",
-  type: OTHER,
-  info: (value) =>
-    `Your Sprint creates a water sphere behind you. After you stop, it surges ahead and bursts for ${value} damage`,
-  values: {
-    [DUO]: { 1: 140 },
-  },
-  prerequisites: [
-    [blindingSprint, lucidGain],
-    [breakerSprint, fluidGain],
-  ],
-};
-
-const scaldingVapor: Boon = {
-  name: "Scalding Vapor",
-  type: OTHER,
-  info: (value) =>
-    `If foes with [slip] are struck with fire from Hestia, they are engulfed in [steam] that deals ${value} damage every 0.2 seconds`,
-  values: {
-    [DUO]: { 1: 25 },
-  },
-  prerequisites: [
-    [slipperySlope],
-    [
-      flameStrike,
-      flameFlourish,
-      smolderRing,
-      spontaneousCombustion,
-      burningDesire,
-      controlledBurn,
-      glowingCoal,
-    ],
-  ],
-};
-
 const abilities = {
   attack,
   special,
@@ -361,13 +219,6 @@ const abilities = {
   slipperySlope,
   crashingWave,
   kingTide,
-  islandGetaway,
-  naturalSelection,
-  killerCurrent,
-  seismicHammer,
-  goldenRule,
-  beachBall,
-  scaldingVapor,
 };
 
 export const poseidon: God = {

--- a/src/data/gods/zeus.ts
+++ b/src/data/gods/zeus.ts
@@ -206,21 +206,6 @@ const doubleStrike: Boon = {
   ],
 };
 
-const kingsRansom: Boon = {
-  name: "King's Ransom",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Give up all your Boons of Hera. For each raise all of your Boons of Zeus by ${value} levels`,
-  values: {
-    [DUO]: { 1: 2 },
-  },
-  prerequisites: [
-    [swornFlourish, swornStrike, engagementRing, nexusSprint, bornGain],
-    [heavenFlourish, heavenStrike, stormRing, thunderSprint, ionicGain],
-  ],
-};
-
 const electricOverload: Boon = {
   name: "Electric Overload",
   type: OTHER,
@@ -232,21 +217,6 @@ const electricOverload: Boon = {
     [RARE]: { 1: 15 },
   },
   prerequisites: [[heavenFlourish, heavenStrike]],
-};
-
-const masterConductor: Boon = {
-  name: "Master Conductor",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your chain-lightning deals ${value} more damage per bounce and can bounce to you`,
-  values: {
-    [DUO]: { 1: "15%" },
-  },
-  prerequisites: [
-    [staticShock],
-    [fixedGain, trustyShield, heavyMetal, mintCondition, toughTrade],
-  ],
 };
 
 const toastingFork: Boon = {
@@ -273,85 +243,6 @@ const shockingLoss: Boon = {
   },
 };
 
-const gloriousDisaster: Boon = {
-  name: "Glorious Disaster",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `You can Channel +30 [mana] into your [omega] Cast to repeatedly strike foes for ${value} bolt damage every 0.13 seconds`,
-  values: {
-    [LEGENDARY]: { 1: 50 },
-  },
-  prerequisites: [[solarRing], [heavenStrike, heavenFlourish, thunderSprint]],
-};
-
-const apocalypticStorm: Boon = {
-  name: "Apocalyptic Storm",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your [blitz] effects last ${value} seconds longer, and active against all [blitz]-afflicted foes at once`,
-  values: {
-    [DUO]: { 1: 8 },
-  },
-  prerequisites: [
-    [iceStrike, iceFlourish, arcticRing, frigidSprint],
-    [heavenStrike, heavenFlourish],
-  ],
-};
-
-const thermalDynamics: Boon = {
-  name: "Thermal Dynamics",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your [blitz] effects also inflict ${value} [scorch] whenever they deal damage`,
-  values: {
-    [DUO]: { 1: 80 },
-  },
-  prerequisites: [
-    [heavenStrike, heavenFlourish],
-    [flameFlourish, flameStrike],
-  ],
-};
-
-const killerCurrent: Boon = {
-  name: "Killer Current",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `Your lightning deals ${value} bonus damage to [slip]-afflicted foes`,
-  values: {
-    [DUO]: { 1: "30%" },
-  },
-  prerequisites: [
-    [slipperySlope],
-    [
-      heavenStrike,
-      heavenFlourish,
-      stormRing,
-      thunderSprint,
-      divineVengeance,
-      lightningLance,
-    ],
-  ],
-};
-
-const romanticSpark: Boon = {
-  name: "Romantic Spark",
-  type: OTHER,
-  element: COSMIC,
-  info: (value) =>
-    `If you Sprint into [blitz]-afflicted foes, the effect actives immediately and is ${value} stronger`,
-  values: {
-    [DUO]: { 1: "200%" },
-  },
-  prerequisites: [
-    [heavenFlourish, heavenStrike],
-    [passionDash, raptureRing, flutterFlourish, flutterStrike],
-  ],
-};
-
 const abilities = {
   attack,
   special,
@@ -364,16 +255,9 @@ const abilities = {
   staticShock,
   doubleStrike,
   spiritSurge,
-  "king's ransom": kingsRansom,
   electricOverload,
-  masterConductor,
   toastingFork,
   shockingLoss,
-  gloriousDisaster,
-  apocalypticStorm,
-  thermalDynamics,
-  killerCurrent,
-  romanticSpark,
 };
 
 export const zeus: God = {


### PR DESCRIPTION
Pulls all Duos out of the individual gods into a special data file. This started as a fix to a previous bug (duo reqs commands like !burning desire reqs were not working because of a circular dependency issue). However, I think the change moves in a safer direction long term.

This opens up the potential for a !duo god1 god2 command, which I'd like to implement next. Often on runs I'm curious to look up a duo based on gods that I've already contracted with.